### PR TITLE
feat(baking): add baking service type definitions

### DIFF
--- a/apps/openbadges-modular-server/src/services/baking/index.ts
+++ b/apps/openbadges-modular-server/src/services/baking/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Baking Service
+ *
+ * Exports for embedding Open Badges credentials into images.
+ */
+
+export * from './types';

--- a/apps/openbadges-modular-server/src/services/baking/types.ts
+++ b/apps/openbadges-modular-server/src/services/baking/types.ts
@@ -9,7 +9,7 @@
  * verification, making badges portable and shareable.
  */
 
-import type { OB2, OB3 } from 'openbadges-types';
+import type { OB2, OB3, OpenBadgesVersion } from 'openbadges-types';
 
 /**
  * Supported image formats for badge baking
@@ -45,6 +45,7 @@ export interface BakeOptions {
 
   /**
    * Whether to preserve existing embedded credentials
+   * When true, throws an error if credential data already exists
    * When false, any existing baked data will be replaced
    * @default false
    */
@@ -106,7 +107,7 @@ export interface UnbakeResult {
   /**
    * The detected Open Badges version of the credential
    */
-  version?: '2.0' | '3.0';
+  version?: OpenBadgesVersion;
 
   /**
    * The format of the source image


### PR DESCRIPTION
## Summary
- Add TypeScript type definitions for the badge baking service in `apps/openbadges-modular-server/src/services/baking/types.ts`
- Define `BakingService` interface with `bake()`, `unbake()`, `detectFormat()`, and `isBaked()` methods
- Add `BakedImage`, `UnbakeResult`, `BakeOptions` types and `ImageFormat` type supporting PNG and SVG

## Test plan
- [x] `bun run type-check` passes
- [x] `bun run lint` passes (no new warnings)
- [ ] Types will be validated by implementation in follow-up PRs

Closes #114

@coderabbitai full review

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for embedding and extracting credentials in badge images (PNG and SVG formats), enabling new credential storage and verification capabilities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->