### PR TITLE
fix(openbadges-types): export OB3.Profile from v3 namespace

### DIFF
--- a/packages/openbadges-types/src/v3/index.ts
+++ b/packages/openbadges-types/src/v3/index.ts
@@ -1,4 +1,5 @@
 export * from "./guards";
+export * from "./Profile";
 import type {
   IRI,
   DateTime,


### PR DESCRIPTION
## Summary

The `Profile` interface existed in `v3/Profile.ts` but was not exported from `v3/index.ts`, causing `OB3.Profile` to be undefined for consumers.

## Changes

- Added `export * from "./Profile";` to `packages/openbadges-types/src/v3/index.ts`

## Validation

- `bun --filter openbadges-types build` ✅
- `bun --filter openbadges-types test` ✅ (158 tests pass)

## Impact

This fix unblocks 6 type errors in `openbadges-ui` components that reference `OB3.Profile`:
- `IssuerCard.vue`
- `IssuerList.vue`

Closes #226

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)