### PR TITLE
fix(openbadges-system): map OB3 credentialSubject to IdentityObject in normalizeAssertionData (#286)

### DIFF
--- a/apps/openbadges-system/src/client/composables/useBadges.test.ts
+++ b/apps/openbadges-system/src/client/composables/useBadges.test.ts
@@ -363,6 +363,45 @@ describe('useBadges', () => {
         })
       })
 
+      it('should default to "unknown" type when identityType is undefined', () => {
+        const ob3Credential: OB3.VerifiableCredential = {
+          '@context': [
+            'https://www.w3.org/2018/credentials/v1',
+            'https://purl.imsglobal.org/spec/ob/v3p0/context.json',
+          ],
+          id: iri('https://example.org/credentials/1'),
+          type: ['VerifiableCredential', 'OpenBadgeCredential'],
+          issuer: iri('https://example.org/issuer'),
+          validFrom: dateTime('2024-01-01T00:00:00Z'),
+          credentialSubject: {
+            identifier: [
+              {
+                identityHash: 'xyz789abc012',
+                hashed: false,
+              } as OB3.IdentityObject,
+            ],
+            achievement: {
+              id: iri('https://example.org/achievements/1'),
+              type: 'Achievement',
+              name: 'Test Achievement',
+              description: 'A test achievement',
+              criteria: {
+                narrative: 'Complete the test',
+              },
+            },
+          },
+        }
+
+        const normalized = composable.normalizeAssertionData(ob3Credential)
+
+        expect(normalized.recipient).toEqual({
+          type: 'unknown',
+          identity: 'xyz789abc012',
+          hashed: false,
+          salt: undefined,
+        })
+      })
+
       it('should extract identity from credentialSubject.id as fallback', () => {
         const ob3Credential: OB3.VerifiableCredential = {
           '@context': [

--- a/apps/openbadges-system/src/client/composables/useBadges.ts
+++ b/apps/openbadges-system/src/client/composables/useBadges.ts
@@ -170,7 +170,7 @@ const extractIdentityFromCredentialSubject = (
     return {
       type: ob3Identity.identityType || 'unknown',
       identity: ob3Identity.identityHash,
-      hashed: ob3Identity.hashed,
+      hashed: ob3Identity.hashed ?? false,
       salt: ob3Identity.salt,
     }
   }


### PR DESCRIPTION
## Summary

- **Fix type mismatch** in `normalizeAssertionData` where OB3 credentials returned `CredentialSubject` instead of `IdentityObject` for the `recipient` field
- **Add identity extraction helper** that maps OB3 `CredentialSubject` to OB2-compatible `IdentityObject` structure
- **Comprehensive test coverage** with 6 new test cases for identity extraction scenarios

## Problem

The `normalizeAssertionData` function returned different types for the `recipient` field:
- **OB2**: `IdentityObject` with `{ type, identity, hashed, salt? }`
- **OB3**: `CredentialSubject` with `{ id?, achievement, email?, identifier?, ... }`

This caused runtime errors when UI components (e.g., `admin/badges.vue:464`) tried to access `recipient.identity` on OB3 data.

## Solution

Implemented **Option B** from the issue: Map OB3 `CredentialSubject` to OB2-compatible `IdentityObject` structure.

**Identity Extraction Priority:**
1. `credentialSubject.email` → `{ type: 'email', identity: email, hashed: false }`
2. `credentialSubject.identifier[0]` → Map OB3.IdentityObject fields to OB2 format
3. `credentialSubject.id` → `{ type: 'id', identity: id, hashed: false }`
4. Anonymous fallback → `{ type: 'unknown', identity: 'anonymous', hashed: false }`

## Changes

| File | Changes |
|------|---------|
| `useBadges.ts` | +60 lines - Added `extractIdentityFromCredentialSubject` helper |
| `useBadges.test.ts` | +216 lines - Added 6 comprehensive test cases |

## Test Plan

- [x] Extract identity from `credentialSubject.email`
- [x] Extract identity from `credentialSubject.identifier` array
- [x] Fallback to `credentialSubject.id` (DID/IRI)
- [x] Anonymous fallback when no identity present
- [x] Handle missing `identityType` field (defaults to 'unknown')
- [x] OB2 identity passthrough (unchanged)
- [x] All 92 tests pass
- [x] Lint passes
- [x] Type-check passes for modified files

## Review Notes

**Pre-existing type errors:** The codebase has pre-existing type errors in `admin/badges.vue`, `edit.vue`, and `issue.vue` related to OB2/OB3 type unions. These are **not introduced by this PR** and should be addressed in a separate issue.

Closes #286