### PR TITLE
fix(openbadges-system): Use Achievement type when creating OB3 badges (#287)

### DIFF
--- a/apps/openbadges-system/src/client/composables/useBadges.test.ts
+++ b/apps/openbadges-system/src/client/composables/useBadges.test.ts
@@ -753,6 +753,14 @@ describe('useBadges', () => {
         writable: true,
         configurable: true,
       })
+      // Mock crypto.randomUUID for deterministic testing
+      Object.defineProperty(globalThis, 'crypto', {
+        value: {
+          randomUUID: () => '550e8400-e29b-41d4-a716-446655440000',
+        },
+        writable: true,
+        configurable: true,
+      })
       composable = useBadges()
     })
 

--- a/apps/openbadges-system/src/client/composables/useBadges.ts
+++ b/apps/openbadges-system/src/client/composables/useBadges.ts
@@ -402,7 +402,8 @@ export const useBadges = () => {
       if (isOB3) {
         // OB3 Achievement format
         // Generate ID if not provided (backend will use this or generate its own)
-        const achievementId = badgeData.id || `${window.location.origin}/achievements/${Date.now()}`
+        const achievementId =
+          badgeData.id || `${window.location.origin}/achievements/${crypto.randomUUID()}`
 
         payload = {
           '@context': 'https://purl.imsglobal.org/spec/ob/v3p0/context.json',


### PR DESCRIPTION
## Summary

Fixes the `createBadge` function to conditionally create OB2 BadgeClass or OB3 Achievement payloads based on the `specVersion` setting.

### Changes

- **OB3 (specVersion '3.0')**: Uses `type: 'Achievement'`, `@context`, `creator`, `alignments`, and routes to `/achievements` endpoint
- **OB2 (specVersion '2.0')**: Uses `type: 'BadgeClass'`, `issuer`, `alignment`, and routes to `/badge-classes` endpoint

### Implementation Details

| Field | OB2 | OB3 |
|-------|-----|-----|
| type | `'BadgeClass'` | `'Achievement'` |
| issuer/creator | `issuer` | `creator` (mapped from issuer) |
| alignment | `alignment` (singular) | `alignments` (plural) |
| context | Not included | `@context: 'https://purl.imsglobal.org/spec/ob/v3p0/context.json'` |
| id | Optional | Required (generated client-side) |
| endpoint | `/badge-classes` | `/achievements` |

### Commits

1. `fix(openbadges-system): use Achievement type when creating OB3 badges` - Core implementation
2. `test(openbadges-system): add OB2/OB3 createBadge payload tests` - Test coverage
3. `fix(openbadges-system): resolve lint and type errors in createBadge tests` - Test fixes
4. `fix(openbadges-system): add @context for OB3 Achievement payloads` - OB3 compliance fix

## Test Plan

- [x] All useBadges tests pass (43/43)
- [x] Type-check passes
- [x] Lint passes (no new errors)
- [x] Build passes
- [x] OB3 compliance review completed

### Tests Added

- OB2 BadgeClass payload format and endpoint verification
- OB3 Achievement payload format and endpoint verification
- Required OB3 fields (id, type, name, description, criteria, @context)
- Field mappings (issuer→creator, alignment→alignments)
- OB3-specific fields excluded from OB2 (tags)

## OB3 Compliance Notes

Reviewed by openbadges-compliance-reviewer agent:
- ✅ Uses correct `'Achievement'` type for OB3
- ✅ Includes required `@context` for JSON-LD processing
- ✅ Field mappings are spec-compliant (issuer→creator, alignment→alignments)
- ✅ Generates required `id` field for OB3

Closes #287

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced badge creation to support both OpenBadges 2 and OpenBadges 3 formats with automatic version-specific handling.

* **Tests**
  * Added comprehensive test coverage for badge payload construction across both supported badge formats.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->