### PR TITLE
fix(ci): update Dependabot to use Bun ecosystem and fix lockfile reference

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 version: 2
 updates:
   # Root package.json and bun.lock
-  # Dependabot uses npm ecosystem for Bun workspaces
-  - package-ecosystem: "npm"
+  # Dependabot now natively supports Bun (GA Feb 2025)
+  - package-ecosystem: "bun"
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
 
@@ -59,7 +59,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
 
@@ -99,7 +99,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
 
@@ -139,7 +139,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
 
@@ -166,7 +166,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lockb') }}
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
 


### PR DESCRIPTION
## Summary

- Change Dependabot package-ecosystem from `npm` to `bun` (now [GA since Feb 2025](https://github.blog/changelog/2025-02-13-dependabot-version-updates-now-support-the-bun-package-manager-ga/))
- Update CI cache key from `bun.lockb` to `bun.lock` (text-based lockfile)

## Problem

Dependabot PRs (like #307) were failing because:

1. **Wrong lockfile reference**: CI uses `hashFiles('**/bun.lockb')` but we migrated to text-based `bun.lock`
2. **Wrong ecosystem**: Dependabot was using `npm` ecosystem which doesn't update `bun.lock`

## Solution

- Use native `bun` ecosystem in Dependabot (now officially supported)
- Fix cache key to reference the actual lockfile name

## After Merge

- PR #306 (actions/cache v4→v5): Can be merged as-is
- PR #307 (24 dev deps): Should be closed; Dependabot will recreate with proper `bun.lock` updates

## Test plan

- [x] Verify CI passes on this PR
- [ ] After merge, verify new Dependabot PRs include `bun.lock` updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency management configuration to use Bun package manager ecosystem
  * Optimized CI workflow caching strategy for improved build performance

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->