### PR TITLE
feat(openbadges-server): support multiple proofs per credential

### DIFF
--- a/apps/openbadges-modular-server/src/infrastructure/database/modules/postgresql/repositories/postgres-api-key.repository.ts
+++ b/apps/openbadges-modular-server/src/infrastructure/database/modules/postgresql/repositories/postgres-api-key.repository.ts
@@ -134,10 +134,13 @@ export class PostgresApiKeyRepository implements ApiKeyRepository {
 
       return result.map((record) => this.toDomain(record));
     } catch (error) {
-      logger.error("Error finding API Keys by user ID in PostgreSQL repository", {
-        error: error instanceof Error ? error.stack : String(error),
-        userId,
-      });
+      logger.error(
+        "Error finding API Keys by user ID in PostgreSQL repository",
+        {
+          error: error instanceof Error ? error.stack : String(error),
+          userId,
+        },
+      );
       throw error;
     }
   }
@@ -179,12 +182,18 @@ export class PostgresApiKeyRepository implements ApiKeyRepository {
       };
 
       if (data.name !== undefined) updateValues.name = data.name;
-      if (data.description !== undefined) updateValues.description = data.description;
-      if (data.permissions !== undefined) updateValues.permissions = data.permissions;
+      if (data.description !== undefined)
+        updateValues.description = data.description;
+      if (data.permissions !== undefined)
+        updateValues.permissions = data.permissions;
       if (data.revoked !== undefined) updateValues.revoked = data.revoked;
-      if (data.lastUsedAt !== undefined) updateValues.lastUsed = data.lastUsedAt;
+      if (data.lastUsedAt !== undefined)
+        updateValues.lastUsed = data.lastUsedAt;
 
-      await this.db.update(apiKeys).set(updateValues).where(eq(apiKeys.id, dbId));
+      await this.db
+        .update(apiKeys)
+        .set(updateValues)
+        .where(eq(apiKeys.id, dbId));
 
       // Fetch and return updated record
       return this.findById(id);
@@ -278,10 +287,13 @@ export class PostgresApiKeyRepository implements ApiKeyRepository {
 
       return this.findById(id);
     } catch (error) {
-      logger.error("Error updating API Key last used in PostgreSQL repository", {
-        error: error instanceof Error ? error.stack : String(error),
-        id,
-      });
+      logger.error(
+        "Error updating API Key last used in PostgreSQL repository",
+        {
+          error: error instanceof Error ? error.stack : String(error),
+          id,
+        },
+      );
       throw error;
     }
   }
@@ -297,15 +309,11 @@ export class PostgresApiKeyRepository implements ApiKeyRepository {
     apiKey.id = convertUuid(
       record.id as string,
       "postgresql",
-      "from"
+      "from",
     ) as Shared.IRI;
     apiKey.key = record.key as string;
     apiKey.name = record.name as string;
-    apiKey.userId = convertUuid(
-      record.userId as string,
-      "postgresql",
-      "from"
-    );
+    apiKey.userId = convertUuid(record.userId as string, "postgresql", "from");
     apiKey.description = record.description as string | undefined;
     apiKey.permissions = record.permissions as ApiKeyPermissions;
     apiKey.revoked = Boolean(record.revoked);

--- a/apps/openbadges-modular-server/src/infrastructure/database/modules/sqlite/repositories/sqlite-api-key.repository.ts
+++ b/apps/openbadges-modular-server/src/infrastructure/database/modules/sqlite/repositories/sqlite-api-key.repository.ts
@@ -191,12 +191,19 @@ export class SqliteApiKeyRepository implements ApiKeyRepository {
       };
 
       if (data.name !== undefined) updateValues.name = data.name;
-      if (data.description !== undefined) updateValues.description = data.description;
-      if (data.permissions !== undefined) updateValues.permissions = JSON.stringify(data.permissions);
-      if (data.revoked !== undefined) updateValues.revoked = data.revoked ? 1 : 0;
-      if (data.lastUsedAt !== undefined) updateValues.lastUsed = data.lastUsedAt.getTime();
+      if (data.description !== undefined)
+        updateValues.description = data.description;
+      if (data.permissions !== undefined)
+        updateValues.permissions = JSON.stringify(data.permissions);
+      if (data.revoked !== undefined)
+        updateValues.revoked = data.revoked ? 1 : 0;
+      if (data.lastUsedAt !== undefined)
+        updateValues.lastUsed = data.lastUsedAt.getTime();
 
-      await db.update(apiKeys).set(updateValues).where(eq(apiKeys.id, id as string));
+      await db
+        .update(apiKeys)
+        .set(updateValues)
+        .where(eq(apiKeys.id, id as string));
 
       // Fetch and return updated record
       return this.findById(id);

--- a/apps/openbadges-modular-server/src/services/verification/types.ts
+++ b/apps/openbadges-modular-server/src/services/verification/types.ts
@@ -117,6 +117,13 @@ export interface VerificationOptions {
 
   /** Maximum age of proof creation timestamp in seconds */
   maxProofAge?: number;
+
+  /**
+   * Policy for verifying multiple proofs in a credential
+   * - 'all': All proofs must pass (default, strictest)
+   * - 'any': At least one proof must pass
+   */
+  proofPolicy?: "all" | "any";
 }
 
 /**
@@ -147,6 +154,29 @@ export interface VerificationKeyMaterial {
 }
 
 /**
+ * Result of verifying an individual proof within a multi-proof credential
+ */
+export interface ProofVerificationResult {
+  /** Index of the proof in the proof array (0-based) */
+  index: number;
+
+  /** Type of the proof */
+  proofType: ProofType | "jwt";
+
+  /** Whether this proof passed verification */
+  passed: boolean;
+
+  /** Verification method used for this proof */
+  verificationMethod?: Shared.IRI;
+
+  /** Error message if this proof failed */
+  error?: string;
+
+  /** Verification check for this proof */
+  check: VerificationCheck;
+}
+
+/**
  * Complete verification result
  * Contains the overall status and detailed check results
  */
@@ -169,11 +199,20 @@ export interface VerificationResult {
   /** Issuer of the credential */
   issuer?: Shared.IRI;
 
-  /** Proof type used in the credential */
+  /** Proof type used in the credential (primary proof for single-proof credentials) */
   proofType?: ProofType;
 
-  /** Verification method used */
+  /** Verification method used (primary proof for single-proof credentials) */
   verificationMethod?: Shared.IRI;
+
+  /** Results for each individual proof when credential has multiple proofs */
+  proofResults?: ProofVerificationResult[];
+
+  /** Total number of proofs in the credential */
+  totalProofs?: number;
+
+  /** Number of proofs that passed verification */
+  passedProofs?: number;
 
   /** Timestamp when verification was performed */
   verifiedAt: string;

--- a/apps/openbadges-modular-server/tests/services/verification/multiple-proofs.test.ts
+++ b/apps/openbadges-modular-server/tests/services/verification/multiple-proofs.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Tests for Multiple Proofs Support
+ *
+ * Tests the verification service's ability to handle credentials with
+ * multiple proofs as allowed by OB 3.0 and W3C VC Data Model 2.0.
+ */
+
+import { describe, it, expect, beforeAll } from "bun:test";
+import * as jose from "jose";
+import { verify } from "../../../src/services/verification/verification.service.js";
+import type { Shared } from "openbadges-types";
+
+/** Helper to cast string to IRI branded type for tests */
+const asIRI = (s: string): Shared.IRI => s as Shared.IRI;
+
+describe("Multiple Proofs Support", () => {
+  let testKeyPair: jose.GenerateKeyPairResult;
+
+  beforeAll(async () => {
+    testKeyPair = await jose.generateKeyPair("RS256", {
+      extractable: true,
+    });
+  });
+
+  describe("Single Proof Handling", () => {
+    it("should handle credential with single proof object", async () => {
+      const credential = {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json",
+        ],
+        type: ["VerifiableCredential", "OpenBadgeCredential"],
+        issuer: "did:example:issuer",
+        issuanceDate: new Date().toISOString(),
+        credentialSubject: {
+          id: "did:example:subject",
+        },
+        proof: {
+          type: "Ed25519Signature2020",
+          proofPurpose: "assertionMethod",
+          verificationMethod: "did:example:issuer#key-1",
+          proofValue: "z58DAdFfa9SkqZMVPxAQpic7ndSayn1PzZs6ZjWp1CktyGe",
+        },
+      };
+
+      const result = await verify(credential, {
+        skipIssuerVerification: true,
+        skipTemporalValidation: true,
+      });
+
+      // Should have proof results for single proof
+      expect(result.proofResults).toBeDefined();
+      expect(result.proofResults).toHaveLength(1);
+      expect(result.totalProofs).toBe(1);
+      expect(result.proofResults![0].index).toBe(0);
+      expect(result.proofResults![0].proofType).toBe("Ed25519Signature2020");
+    });
+
+    it("should handle credential with no proof field", async () => {
+      const credential = {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json",
+        ],
+        type: ["VerifiableCredential", "OpenBadgeCredential"],
+        issuer: "did:example:issuer",
+        issuanceDate: new Date().toISOString(),
+        credentialSubject: {
+          id: "did:example:subject",
+        },
+      };
+
+      const result = await verify(credential, {
+        skipIssuerVerification: true,
+        skipTemporalValidation: true,
+      });
+
+      expect(result.isValid).toBe(false);
+      expect(
+        result.checks.proof.some(
+          (c) => c.check === "proof.linked-data.missing",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("Multiple Proofs Handling", () => {
+    it("should handle credential with multiple proofs (array)", async () => {
+      const credential = {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json",
+        ],
+        type: ["VerifiableCredential", "OpenBadgeCredential"],
+        issuer: "did:example:issuer",
+        issuanceDate: new Date().toISOString(),
+        credentialSubject: {
+          id: "did:example:subject",
+        },
+        proof: [
+          {
+            type: "Ed25519Signature2020",
+            proofPurpose: "assertionMethod",
+            verificationMethod: "did:example:issuer#key-1",
+            proofValue: "z58DAdFfa9SkqZMVPxAQpic7ndSayn1PzZs6ZjWp1CktyGe",
+          },
+          {
+            type: "DataIntegrityProof",
+            cryptosuite: "eddsa-rdfc-2022",
+            proofPurpose: "assertionMethod",
+            verificationMethod: "did:example:issuer#key-2",
+            proofValue: "z12345",
+          },
+        ],
+      };
+
+      const result = await verify(credential, {
+        skipIssuerVerification: true,
+        skipTemporalValidation: true,
+      });
+
+      // Should have proof results for all proofs
+      expect(result.proofResults).toBeDefined();
+      expect(result.proofResults).toHaveLength(2);
+      expect(result.totalProofs).toBe(2);
+
+      // First proof
+      expect(result.proofResults![0].index).toBe(0);
+      expect(result.proofResults![0].proofType).toBe("Ed25519Signature2020");
+
+      // Second proof
+      expect(result.proofResults![1].index).toBe(1);
+      expect(result.proofResults![1].proofType).toBe("DataIntegrityProof");
+    });
+
+    it("should extract verification methods from each proof", async () => {
+      const credential = {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json",
+        ],
+        type: ["VerifiableCredential", "OpenBadgeCredential"],
+        issuer: "did:example:issuer",
+        issuanceDate: new Date().toISOString(),
+        credentialSubject: {
+          id: "did:example:subject",
+        },
+        proof: [
+          {
+            type: "Ed25519Signature2020",
+            proofPurpose: "assertionMethod",
+            verificationMethod: "did:example:issuer#key-1",
+            proofValue: "z58D",
+          },
+          {
+            type: "Ed25519Signature2020",
+            proofPurpose: "assertionMethod",
+            verificationMethod: "did:example:issuer#key-2",
+            proofValue: "z59E",
+          },
+        ],
+      };
+
+      const result = await verify(credential, {
+        skipIssuerVerification: true,
+        skipTemporalValidation: true,
+      });
+
+      expect(result.proofResults![0].verificationMethod).toBe(
+        asIRI("did:example:issuer#key-1"),
+      );
+      expect(result.proofResults![1].verificationMethod).toBe(
+        asIRI("did:example:issuer#key-2"),
+      );
+    });
+  });
+
+  describe("Proof Policy", () => {
+    it("should apply 'all' policy by default (all proofs must pass)", async () => {
+      const credential = {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json",
+        ],
+        type: ["VerifiableCredential", "OpenBadgeCredential"],
+        issuer: "did:example:issuer",
+        issuanceDate: new Date().toISOString(),
+        credentialSubject: {
+          id: "did:example:subject",
+        },
+        proof: [
+          {
+            type: "Ed25519Signature2020",
+            proofPurpose: "assertionMethod",
+            verificationMethod: "did:example:issuer#key-1",
+            proofValue: "z58D",
+          },
+          {
+            type: "Ed25519Signature2020",
+            proofPurpose: "assertionMethod",
+            verificationMethod: "did:example:issuer#key-2",
+            proofValue: "z59E",
+          },
+        ],
+      };
+
+      const result = await verify(credential, {
+        skipIssuerVerification: true,
+        skipTemporalValidation: true,
+        // proofPolicy defaults to 'all'
+      });
+
+      // Should have a policy check for multi-proof
+      const policyCheck = result.checks.proof.find(
+        (c) => c.check === "proof.policy",
+      );
+      expect(policyCheck).toBeDefined();
+      expect(policyCheck?.details?.policy).toBe("all");
+    });
+
+    it("should apply 'any' policy when specified", async () => {
+      const credential = {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json",
+        ],
+        type: ["VerifiableCredential", "OpenBadgeCredential"],
+        issuer: "did:example:issuer",
+        issuanceDate: new Date().toISOString(),
+        credentialSubject: {
+          id: "did:example:subject",
+        },
+        proof: [
+          {
+            type: "Ed25519Signature2020",
+            proofPurpose: "assertionMethod",
+            verificationMethod: "did:example:issuer#key-1",
+            proofValue: "z58D",
+          },
+          {
+            type: "Ed25519Signature2020",
+            proofPurpose: "assertionMethod",
+            verificationMethod: "did:example:issuer#key-2",
+            proofValue: "z59E",
+          },
+        ],
+      };
+
+      const result = await verify(credential, {
+        skipIssuerVerification: true,
+        skipTemporalValidation: true,
+        proofPolicy: "any",
+      });
+
+      const policyCheck = result.checks.proof.find(
+        (c) => c.check === "proof.policy",
+      );
+      expect(policyCheck).toBeDefined();
+      expect(policyCheck?.details?.policy).toBe("any");
+      expect(policyCheck?.details?.requiredToPass).toBe(1);
+    });
+
+    it("should report correct passed/total counts", async () => {
+      const credential = {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json",
+        ],
+        type: ["VerifiableCredential", "OpenBadgeCredential"],
+        issuer: "did:example:issuer",
+        issuanceDate: new Date().toISOString(),
+        credentialSubject: {
+          id: "did:example:subject",
+        },
+        proof: [
+          {
+            type: "Ed25519Signature2020",
+            proofPurpose: "assertionMethod",
+            verificationMethod: "did:example:issuer#key-1",
+            proofValue: "z58D",
+          },
+          {
+            type: "DataIntegrityProof",
+            cryptosuite: "eddsa-rdfc-2022",
+            proofPurpose: "assertionMethod",
+            verificationMethod: "did:example:issuer#key-2",
+            proofValue: "z12345",
+          },
+          {
+            type: "JsonWebSignature2020",
+            proofPurpose: "assertionMethod",
+            verificationMethod: "did:example:issuer#key-3",
+            jws: "eyJhbGciOiJFZERTQSJ9.test.signature",
+          },
+        ],
+      };
+
+      const result = await verify(credential, {
+        skipIssuerVerification: true,
+        skipTemporalValidation: true,
+      });
+
+      expect(result.totalProofs).toBe(3);
+      // All proofs fail as Linked Data verification is not implemented yet
+      expect(result.passedProofs).toBe(0);
+    });
+  });
+
+  describe("JWT Credentials", () => {
+    it("should handle JWT credentials as single proof", async () => {
+      const jwt = await new jose.SignJWT({
+        vc: {
+          "@context": ["https://www.w3.org/2018/credentials/v1"],
+          type: ["VerifiableCredential", "OpenBadgeCredential"],
+          issuer: "https://example.com/issuer",
+          issuanceDate: new Date().toISOString(),
+          credentialSubject: {
+            id: "did:example:123",
+          },
+        },
+      })
+        .setProtectedHeader({
+          alg: "RS256",
+          typ: "vc+jwt",
+          kid: "test-key-1",
+        })
+        .setIssuedAt()
+        .setIssuer("https://example.com/issuer")
+        .sign(testKeyPair.privateKey);
+
+      const mockResolver = async () => testKeyPair.publicKey;
+
+      const result = await verify(jwt, {
+        skipIssuerVerification: true,
+        skipTemporalValidation: true,
+        verificationMethodResolver: mockResolver,
+      });
+
+      // JWT has single proof
+      expect(result.totalProofs).toBe(1);
+      expect(result.proofResults).toBeDefined();
+      expect(result.proofResults).toHaveLength(1);
+      expect(result.proofResults![0].proofType).toBe("jwt");
+      expect(result.proofResults![0].passed).toBe(true);
+    });
+  });
+
+  describe("Skip Proof Verification", () => {
+    it("should not include proof results when skipProofVerification is true", async () => {
+      const credential = {
+        "@context": [
+          "https://www.w3.org/2018/credentials/v1",
+          "https://purl.imsglobal.org/spec/ob/v3p0/context-3.0.3.json",
+        ],
+        type: ["VerifiableCredential", "OpenBadgeCredential"],
+        issuer: "did:example:issuer",
+        issuanceDate: new Date().toISOString(),
+        credentialSubject: {
+          id: "did:example:subject",
+        },
+        proof: [
+          {
+            type: "Ed25519Signature2020",
+            proofPurpose: "assertionMethod",
+            verificationMethod: "did:example:issuer#key-1",
+            proofValue: "z58D",
+          },
+        ],
+      };
+
+      const result = await verify(credential, {
+        skipIssuerVerification: true,
+        skipTemporalValidation: true,
+        skipProofVerification: true,
+      });
+
+      // No proof results when verification is skipped
+      expect(result.proofResults).toBeUndefined();
+      expect(result.totalProofs).toBeUndefined();
+      expect(result.passedProofs).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Implements support for verifying credentials with multiple proofs as allowed by Open Badges 3.0 and W3C VC Data Model 2.0.

- Add `proofPolicy` option ('all' | 'any') to VerificationOptions
  - `all` (default): All proofs must pass verification
  - `any`: At least one proof must pass verification
- Add `ProofVerificationResult` type for per-proof results
- Add `extractProofs()` to handle both single proof and proof array formats
- Update `verify()` to iterate over all proofs and apply policy
- Add `proofResults`, `totalProofs`, `passedProofs` to VerificationResult
- Allow linked data credentials without top-level verificationMethod (each proof has its own)

## Test plan

- [x] Run test suite: `bun test tests/services/verification/multiple-proofs.test.ts`
- [x] 9 tests for multiple proofs functionality pass
- [x] All 62 verification tests pass
- [x] Type-check passes
- [x] Lint passes

## Note

This PR depends on #309 for full Linked Data proof verification. Currently linked data proofs are tracked but not cryptographically verified (pending #309 merge). The infrastructure for multi-proof handling is complete and tested.

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added multi-proof verification support enabling credentials with multiple proofs to be verified using configurable policies (all or any).
  * Verification results now include detailed per-proof outcomes and summary statistics (total and passed proof counts).

* **Tests**
  * Expanded test coverage for multi-proof verification scenarios across various credential types and policy configurations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->