### PR TITLE
fix(openbadges-server): Implement API key repositories (#320)

### DIFF
--- a/apps/openbadges-modular-server/src/infrastructure/database/modules/postgresql/repositories/postgres-api-key.repository.ts
+++ b/apps/openbadges-modular-server/src/infrastructure/database/modules/postgresql/repositories/postgres-api-key.repository.ts
@@ -2,133 +2,317 @@
  * PostgreSQL implementation of the API Key repository
  *
  * This class implements the ApiKeyRepository interface using PostgreSQL
- * and the Data Mapper pattern.
+ * and the Data Mapper pattern with Drizzle ORM.
  */
 
-// import { drizzle } from 'drizzle-orm/postgres-js'; // Will be used in future implementation
+import { eq } from "drizzle-orm";
+import { drizzle } from "drizzle-orm/postgres-js";
 import type postgres from "postgres";
-import type { ApiKey } from "@domains/auth/apiKey.entity";
+import { ApiKey, type ApiKeyPermissions } from "@domains/auth/apiKey.entity";
 import type { ApiKeyRepository } from "@domains/auth/apiKey.repository";
 import type { Shared } from "openbadges-types";
 import { logger } from "@utils/logging/logger.service";
-// These imports will be used in the full implementation
-// import { eq } from 'drizzle-orm';
-// import { apiKeys } from '../schema';
+import { convertUuid } from "@infrastructure/database/utils/type-conversion";
+import { apiKeys } from "../schema";
 
+/**
+ * PostgreSQL implementation of the API Key repository
+ */
 export class PostgresApiKeyRepository implements ApiKeyRepository {
-  // Database client will be used in future implementation
-  constructor(_client: postgres.Sql) {
-    // Store client for future use when implementation is added
+  private db;
+
+  /**
+   * Constructor
+   * @param client PostgreSQL client
+   */
+  constructor(client: postgres.Sql) {
+    this.db = drizzle(client);
   }
 
+  /**
+   * Creates a new API key
+   * @param apiKey The API key to create
+   * @returns The created API key
+   */
   async create(apiKey: ApiKey): Promise<ApiKey> {
     try {
-      // Implementation will be added later
+      // Convert URN to UUID for PostgreSQL
+      const dbId = convertUuid(apiKey.id as string, "postgresql", "to");
+      const dbUserId = convertUuid(apiKey.userId, "postgresql", "to");
+
+      // Insert into database
+      await this.db.insert(apiKeys).values({
+        id: dbId,
+        key: apiKey.key,
+        name: apiKey.name,
+        userId: dbUserId,
+        description: apiKey.description ?? null,
+        permissions: apiKey.permissions,
+        revoked: apiKey.revoked,
+        revokedAt: null,
+        lastUsed: apiKey.lastUsedAt ?? null,
+        createdAt: apiKey.createdAt,
+        updatedAt: apiKey.updatedAt,
+      });
+
       return apiKey;
     } catch (error) {
-      logger.error("Error creating API Key", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error creating API Key in PostgreSQL repository", {
+        error: error instanceof Error ? error.stack : String(error),
+        apiKeyId: apiKey.id,
       });
       throw error;
     }
   }
 
-  async findById(_id: Shared.IRI): Promise<ApiKey | null> {
+  /**
+   * Finds an API key by ID
+   * @param id The API key ID
+   * @returns The API key if found, null otherwise
+   */
+  async findById(id: Shared.IRI): Promise<ApiKey | null> {
     try {
-      // Implementation will be added later
-      return null;
+      const dbId = convertUuid(id as string, "postgresql", "to");
+
+      const result = await this.db
+        .select()
+        .from(apiKeys)
+        .where(eq(apiKeys.id, dbId));
+
+      if (!result.length) {
+        return null;
+      }
+
+      return this.toDomain(result[0]);
     } catch (error) {
-      logger.error("Error finding API Key by ID", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error finding API Key by ID in PostgreSQL repository", {
+        error: error instanceof Error ? error.stack : String(error),
+        id,
       });
       throw error;
     }
   }
 
-  async findByKey(_key: string): Promise<ApiKey | null> {
+  /**
+   * Finds an API key by its key value
+   * @param key The API key value
+   * @returns The API key if found, null otherwise
+   */
+  async findByKey(key: string): Promise<ApiKey | null> {
     try {
-      // Implementation will be added later
-      return null;
+      const result = await this.db
+        .select()
+        .from(apiKeys)
+        .where(eq(apiKeys.key, key));
+
+      if (!result.length) {
+        return null;
+      }
+
+      return this.toDomain(result[0]);
     } catch (error) {
-      logger.error("Error finding API Key by key", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error finding API Key by key in PostgreSQL repository", {
+        error: error instanceof Error ? error.stack : String(error),
       });
       throw error;
     }
   }
 
-  async findByUserId(_userId: string): Promise<ApiKey[]> {
+  /**
+   * Finds all API keys for a user
+   * @param userId The user ID
+   * @returns Array of API keys for the user
+   */
+  async findByUserId(userId: string): Promise<ApiKey[]> {
     try {
-      // Implementation will be added later
-      return [];
+      const dbUserId = convertUuid(userId, "postgresql", "to");
+
+      const result = await this.db
+        .select()
+        .from(apiKeys)
+        .where(eq(apiKeys.userId, dbUserId));
+
+      return result.map((record) => this.toDomain(record));
     } catch (error) {
-      logger.error("Error finding API Keys by user ID", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error finding API Keys by user ID in PostgreSQL repository", {
+        error: error instanceof Error ? error.stack : String(error),
+        userId,
       });
       throw error;
     }
   }
 
+  /**
+   * Finds all API keys
+   * @returns Array of all API keys
+   */
   async findAll(): Promise<ApiKey[]> {
     try {
-      // Implementation will be added later
-      return [];
+      const result = await this.db.select().from(apiKeys);
+      return result.map((record) => this.toDomain(record));
     } catch (error) {
-      logger.error("Error finding all API Keys", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error finding all API Keys in PostgreSQL repository", {
+        error: error instanceof Error ? error.stack : String(error),
       });
       throw error;
     }
   }
 
-  async update(
-    _id: Shared.IRI,
-    _data: Partial<ApiKey>,
-  ): Promise<ApiKey | null> {
+  /**
+   * Updates an API key
+   * @param id The API key ID
+   * @param data The data to update
+   * @returns The updated API key if found, null otherwise
+   */
+  async update(id: Shared.IRI, data: Partial<ApiKey>): Promise<ApiKey | null> {
     try {
-      // Implementation will be added later
-      return null;
+      const existing = await this.findById(id);
+      if (!existing) {
+        return null;
+      }
+
+      const dbId = convertUuid(id as string, "postgresql", "to");
+
+      // Build update values
+      const updateValues: Record<string, unknown> = {
+        updatedAt: new Date(),
+      };
+
+      if (data.name !== undefined) updateValues.name = data.name;
+      if (data.description !== undefined) updateValues.description = data.description;
+      if (data.permissions !== undefined) updateValues.permissions = data.permissions;
+      if (data.revoked !== undefined) updateValues.revoked = data.revoked;
+      if (data.lastUsedAt !== undefined) updateValues.lastUsed = data.lastUsedAt;
+
+      await this.db.update(apiKeys).set(updateValues).where(eq(apiKeys.id, dbId));
+
+      // Fetch and return updated record
+      return this.findById(id);
     } catch (error) {
-      logger.error("Error updating API Key", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error updating API Key in PostgreSQL repository", {
+        error: error instanceof Error ? error.stack : String(error),
+        id,
       });
       throw error;
     }
   }
 
-  async delete(_id: Shared.IRI): Promise<boolean> {
+  /**
+   * Deletes an API key
+   * @param id The API key ID
+   * @returns True if deleted, false otherwise
+   */
+  async delete(id: Shared.IRI): Promise<boolean> {
     try {
-      // Implementation will be added later
-      return false;
+      const dbId = convertUuid(id as string, "postgresql", "to");
+
+      const result = await this.db
+        .delete(apiKeys)
+        .where(eq(apiKeys.id, dbId))
+        .returning({ id: apiKeys.id });
+
+      return result.length > 0;
     } catch (error) {
-      logger.error("Error deleting API Key", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error deleting API Key in PostgreSQL repository", {
+        error: error instanceof Error ? error.stack : String(error),
+        id,
       });
       throw error;
     }
   }
 
-  async revoke(_id: Shared.IRI): Promise<ApiKey | null> {
+  /**
+   * Revokes an API key
+   * @param id The API key ID
+   * @returns The revoked API key if found, null otherwise
+   */
+  async revoke(id: Shared.IRI): Promise<ApiKey | null> {
     try {
-      // Implementation will be added later
-      return null;
+      const existing = await this.findById(id);
+      if (!existing) {
+        return null;
+      }
+
+      const dbId = convertUuid(id as string, "postgresql", "to");
+
+      await this.db
+        .update(apiKeys)
+        .set({
+          revoked: true,
+          revokedAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(apiKeys.id, dbId));
+
+      return this.findById(id);
     } catch (error) {
-      logger.error("Error revoking API Key", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error revoking API Key in PostgreSQL repository", {
+        error: error instanceof Error ? error.stack : String(error),
+        id,
       });
       throw error;
     }
   }
 
-  async updateLastUsed(_id: Shared.IRI): Promise<ApiKey | null> {
+  /**
+   * Updates the last used timestamp for an API key
+   * @param id The API key ID
+   * @returns The updated API key if found, null otherwise
+   */
+  async updateLastUsed(id: Shared.IRI): Promise<ApiKey | null> {
     try {
-      // Implementation will be added later
-      return null;
+      const existing = await this.findById(id);
+      if (!existing) {
+        return null;
+      }
+
+      const dbId = convertUuid(id as string, "postgresql", "to");
+
+      await this.db
+        .update(apiKeys)
+        .set({
+          lastUsed: new Date(),
+          updatedAt: new Date(),
+        })
+        .where(eq(apiKeys.id, dbId));
+
+      return this.findById(id);
     } catch (error) {
-      logger.error("Error updating API Key last used timestamp", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error updating API Key last used in PostgreSQL repository", {
+        error: error instanceof Error ? error.stack : String(error),
+        id,
       });
       throw error;
     }
+  }
+
+  /**
+   * Converts a database record to a domain entity
+   * @param record The database record
+   * @returns The domain entity
+   */
+  private toDomain(record: Record<string, unknown>): ApiKey {
+    const apiKey = new ApiKey();
+
+    apiKey.id = convertUuid(
+      record.id as string,
+      "postgresql",
+      "from"
+    ) as Shared.IRI;
+    apiKey.key = record.key as string;
+    apiKey.name = record.name as string;
+    apiKey.userId = convertUuid(
+      record.userId as string,
+      "postgresql",
+      "from"
+    );
+    apiKey.description = record.description as string | undefined;
+    apiKey.permissions = record.permissions as ApiKeyPermissions;
+    apiKey.revoked = Boolean(record.revoked);
+    apiKey.lastUsedAt = record.lastUsed as Date | undefined;
+    apiKey.createdAt = record.createdAt as Date;
+    apiKey.updatedAt = record.updatedAt as Date;
+
+    return apiKey;
   }
 }

--- a/apps/openbadges-modular-server/src/infrastructure/database/modules/sqlite/repositories/sqlite-api-key.repository.ts
+++ b/apps/openbadges-modular-server/src/infrastructure/database/modules/sqlite/repositories/sqlite-api-key.repository.ts
@@ -2,142 +2,330 @@
  * SQLite implementation of the API Key repository
  *
  * This class implements the ApiKeyRepository interface using SQLite
- * and the Data Mapper pattern.
+ * and the Data Mapper pattern with Drizzle ORM.
  */
 
-// import { drizzle } from 'drizzle-orm/bun-sqlite'; // Will be used in future implementation
-import type { ApiKey } from "@domains/auth/apiKey.entity";
+import { eq } from "drizzle-orm";
+import { ApiKey, type ApiKeyPermissions } from "@domains/auth/apiKey.entity";
 import type { ApiKeyRepository } from "@domains/auth/apiKey.repository";
 import type { Shared } from "openbadges-types";
 import { logger } from "@utils/logging/logger.service";
 import type { SqliteConnectionManager } from "../connection/sqlite-connection.manager";
-// These imports will be used in the full implementation
-// import { eq } from 'drizzle-orm';
-// import { apiKeys } from '../schema';
+import { apiKeys } from "../schema";
+import type { drizzle as DrizzleFn } from "drizzle-orm/bun-sqlite";
 
+// Create compile-time type alias to avoid runtime import dependency
+type DrizzleDB = ReturnType<typeof DrizzleFn>;
+
+/**
+ * SQLite implementation of the API Key repository
+ */
 export class SqliteApiKeyRepository implements ApiKeyRepository {
-  constructor(private readonly connectionManager: SqliteConnectionManager) {
-    // Connection manager will be used when implementation is added
-  }
+  /**
+   * Constructor
+   * @param connectionManager SQLite connection manager
+   */
+  constructor(private readonly connectionManager: SqliteConnectionManager) {}
 
   /**
    * Gets the database instance with connection validation
    */
-  private getDatabase() {
+  private getDatabase(): DrizzleDB {
     this.connectionManager.ensureConnected();
     return this.connectionManager.getDatabase();
   }
 
+  /**
+   * Creates a new API key
+   * @param apiKey The API key to create
+   * @returns The created API key
+   */
   async create(apiKey: ApiKey): Promise<ApiKey> {
     try {
-      // Get database with connection validation
-      this.getDatabase();
-      // Implementation will be added later
+      const db = this.getDatabase();
+
+      // Convert dates to integers for SQLite
+      const createdAt = apiKey.createdAt.getTime();
+      const updatedAt = apiKey.updatedAt.getTime();
+      const lastUsed = apiKey.lastUsedAt?.getTime() ?? null;
+
+      // Use type assertion to satisfy Drizzle's strict type inference
+      await db.insert(apiKeys).values({
+        id: apiKey.id as string,
+        key: apiKey.key,
+        name: apiKey.name,
+        userId: apiKey.userId,
+        description: apiKey.description ?? null,
+        permissions: JSON.stringify(apiKey.permissions),
+        revoked: apiKey.revoked ? 1 : 0,
+        revokedAt: null,
+        lastUsed,
+        createdAt,
+        updatedAt,
+      } as typeof apiKeys.$inferInsert);
+
       return apiKey;
     } catch (error) {
-      logger.error("Error creating API Key", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error creating API Key in SQLite repository", {
+        error: error instanceof Error ? error.stack : String(error),
+        apiKeyId: apiKey.id,
       });
       throw error;
     }
   }
 
-  async findById(_id: Shared.IRI): Promise<ApiKey | null> {
+  /**
+   * Finds an API key by ID
+   * @param id The API key ID
+   * @returns The API key if found, null otherwise
+   */
+  async findById(id: Shared.IRI): Promise<ApiKey | null> {
     try {
-      // Implementation will be added later
-      return null;
+      const db = this.getDatabase();
+
+      const result = await db
+        .select()
+        .from(apiKeys)
+        .where(eq(apiKeys.id, id as string));
+
+      if (!result.length) {
+        return null;
+      }
+
+      return this.toDomain(result[0]);
     } catch (error) {
-      logger.error("Error finding API Key by ID", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error finding API Key by ID in SQLite repository", {
+        error: error instanceof Error ? error.stack : String(error),
+        id,
       });
       throw error;
     }
   }
 
-  async findByKey(_key: string): Promise<ApiKey | null> {
+  /**
+   * Finds an API key by its key value
+   * @param key The API key value
+   * @returns The API key if found, null otherwise
+   */
+  async findByKey(key: string): Promise<ApiKey | null> {
     try {
-      // Implementation will be added later
-      return null;
+      const db = this.getDatabase();
+
+      const result = await db
+        .select()
+        .from(apiKeys)
+        .where(eq(apiKeys.key, key));
+
+      if (!result.length) {
+        return null;
+      }
+
+      return this.toDomain(result[0]);
     } catch (error) {
-      logger.error("Error finding API Key by key", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error finding API Key by key in SQLite repository", {
+        error: error instanceof Error ? error.stack : String(error),
       });
       throw error;
     }
   }
 
-  async findByUserId(_userId: string): Promise<ApiKey[]> {
+  /**
+   * Finds all API keys for a user
+   * @param userId The user ID
+   * @returns Array of API keys for the user
+   */
+  async findByUserId(userId: string): Promise<ApiKey[]> {
     try {
-      // Implementation will be added later
-      return [];
+      const db = this.getDatabase();
+
+      const result = await db
+        .select()
+        .from(apiKeys)
+        .where(eq(apiKeys.userId, userId));
+
+      return result.map((record) => this.toDomain(record));
     } catch (error) {
-      logger.error("Error finding API Keys by user ID", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error finding API Keys by user ID in SQLite repository", {
+        error: error instanceof Error ? error.stack : String(error),
+        userId,
       });
       throw error;
     }
   }
 
+  /**
+   * Finds all API keys
+   * @returns Array of all API keys
+   */
   async findAll(): Promise<ApiKey[]> {
     try {
-      // Implementation will be added later
-      return [];
+      const db = this.getDatabase();
+      const result = await db.select().from(apiKeys);
+      return result.map((record) => this.toDomain(record));
     } catch (error) {
-      logger.error("Error finding all API Keys", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error finding all API Keys in SQLite repository", {
+        error: error instanceof Error ? error.stack : String(error),
       });
       throw error;
     }
   }
 
-  async update(
-    _id: Shared.IRI,
-    _data: Partial<ApiKey>,
-  ): Promise<ApiKey | null> {
+  /**
+   * Updates an API key
+   * @param id The API key ID
+   * @param data The data to update
+   * @returns The updated API key if found, null otherwise
+   */
+  async update(id: Shared.IRI, data: Partial<ApiKey>): Promise<ApiKey | null> {
     try {
-      // Implementation will be added later
-      return null;
+      const existing = await this.findById(id);
+      if (!existing) {
+        return null;
+      }
+
+      const db = this.getDatabase();
+
+      // Build update values
+      const updateValues: Record<string, unknown> = {
+        updatedAt: Date.now(),
+      };
+
+      if (data.name !== undefined) updateValues.name = data.name;
+      if (data.description !== undefined) updateValues.description = data.description;
+      if (data.permissions !== undefined) updateValues.permissions = JSON.stringify(data.permissions);
+      if (data.revoked !== undefined) updateValues.revoked = data.revoked ? 1 : 0;
+      if (data.lastUsedAt !== undefined) updateValues.lastUsed = data.lastUsedAt.getTime();
+
+      await db.update(apiKeys).set(updateValues).where(eq(apiKeys.id, id as string));
+
+      // Fetch and return updated record
+      return this.findById(id);
     } catch (error) {
-      logger.error("Error updating API Key", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error updating API Key in SQLite repository", {
+        error: error instanceof Error ? error.stack : String(error),
+        id,
       });
       throw error;
     }
   }
 
-  async delete(_id: Shared.IRI): Promise<boolean> {
+  /**
+   * Deletes an API key
+   * @param id The API key ID
+   * @returns True if deleted, false otherwise
+   */
+  async delete(id: Shared.IRI): Promise<boolean> {
     try {
-      // Implementation will be added later
-      return false;
+      const existing = await this.findById(id);
+      if (!existing) {
+        return false;
+      }
+
+      const db = this.getDatabase();
+      await db.delete(apiKeys).where(eq(apiKeys.id, id as string));
+
+      return true;
     } catch (error) {
-      logger.error("Error deleting API Key", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error deleting API Key in SQLite repository", {
+        error: error instanceof Error ? error.stack : String(error),
+        id,
       });
       throw error;
     }
   }
 
-  async revoke(_id: Shared.IRI): Promise<ApiKey | null> {
+  /**
+   * Revokes an API key
+   * @param id The API key ID
+   * @returns The revoked API key if found, null otherwise
+   */
+  async revoke(id: Shared.IRI): Promise<ApiKey | null> {
     try {
-      // Implementation will be added later
-      return null;
+      const existing = await this.findById(id);
+      if (!existing) {
+        return null;
+      }
+
+      const db = this.getDatabase();
+
+      await db
+        .update(apiKeys)
+        .set({
+          revoked: 1,
+          revokedAt: Date.now(),
+          updatedAt: Date.now(),
+        } as Partial<typeof apiKeys.$inferInsert>)
+        .where(eq(apiKeys.id, id as string));
+
+      return this.findById(id);
     } catch (error) {
-      logger.error("Error revoking API Key", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error revoking API Key in SQLite repository", {
+        error: error instanceof Error ? error.stack : String(error),
+        id,
       });
       throw error;
     }
   }
 
-  async updateLastUsed(_id: Shared.IRI): Promise<ApiKey | null> {
+  /**
+   * Updates the last used timestamp for an API key
+   * @param id The API key ID
+   * @returns The updated API key if found, null otherwise
+   */
+  async updateLastUsed(id: Shared.IRI): Promise<ApiKey | null> {
     try {
-      // Implementation will be added later
-      return null;
+      const existing = await this.findById(id);
+      if (!existing) {
+        return null;
+      }
+
+      const db = this.getDatabase();
+
+      await db
+        .update(apiKeys)
+        .set({
+          lastUsed: Date.now(),
+          updatedAt: Date.now(),
+        } as Partial<typeof apiKeys.$inferInsert>)
+        .where(eq(apiKeys.id, id as string));
+
+      return this.findById(id);
     } catch (error) {
-      logger.error("Error updating API Key last used timestamp", {
-        error: error instanceof Error ? error.message : "Unknown error",
+      logger.error("Error updating API Key last used in SQLite repository", {
+        error: error instanceof Error ? error.stack : String(error),
+        id,
       });
       throw error;
     }
+  }
+
+  /**
+   * Converts a database record to a domain entity
+   * @param record The database record
+   * @returns The domain entity
+   */
+  private toDomain(record: Record<string, unknown>): ApiKey {
+    const apiKey = new ApiKey();
+
+    apiKey.id = record.id as Shared.IRI;
+    apiKey.key = record.key as string;
+    apiKey.name = record.name as string;
+    apiKey.userId = record.userId as string;
+    apiKey.description = record.description as string | undefined;
+
+    // Parse permissions from JSON string
+    const permissions = record.permissions as string;
+    apiKey.permissions = JSON.parse(permissions) as ApiKeyPermissions;
+
+    apiKey.revoked = Boolean(record.revoked);
+
+    // Convert integer timestamps to Date objects
+    if (record.lastUsed) {
+      apiKey.lastUsedAt = new Date(record.lastUsed as number);
+    }
+    apiKey.createdAt = new Date(record.createdAt as number);
+    apiKey.updatedAt = new Date(record.updatedAt as number);
+
+    return apiKey;
   }
 }


### PR DESCRIPTION
## Summary

- Replaced stub implementations with full CRUD operations for both PostgreSQL and SQLite API key repositories
- PostgreSQL: Full create, findById, findByKey, findByUserId, findAll, update, delete, revoke, updateLastUsed operations with UUID conversion and native Date/JSONB support
- SQLite: Same operations with SQLite-specific adaptations (integer timestamps, JSON string permissions, Drizzle type assertions)
- Both implementations follow established Data Mapper pattern and use existing `apiKeys` schema definitions

## Changes Made

### PostgreSQL Repository (`postgres-api-key.repository.ts`)
- Full implementation using `drizzle-orm/postgres-js`
- UUID conversion via `convertUuid` utility for domain-to-DB mapping
- Native PostgreSQL Date and JSONB types for timestamps and permissions

### SQLite Repository (`sqlite-api-key.repository.ts`)
- Full implementation using `drizzle-orm/bun-sqlite` 
- Integer timestamps (epoch milliseconds) for date storage
- JSON string serialization for permissions field
- Type assertions (`as typeof apiKeys.$inferInsert`) for Drizzle ORM type inference

## Test Plan

- [x] Type-check passes
- [x] Lint passes (0 errors)
- [x] Existing tests pass (928 pass, 2 pre-existing failures unrelated to this change)
- [ ] API key CRUD operations work with both database backends

Closes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Completed full API key repository implementations for PostgreSQL and SQLite with functional create/read/update/delete, revoke, and last-used tracking.
  * Improved data persistence for timestamps and permissions, plus more informative error logging.
  * Added reliable domain-to-database mapping so API key operations now return consistent, fully populated entities.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->