### PR TITLE
feat(openbadges-server): implement DID resolution for proof verification

### DIFF
--- a/apps/openbadges-modular-server/src/services/verification/proof-verifier.ts
+++ b/apps/openbadges-modular-server/src/services/verification/proof-verifier.ts
@@ -331,7 +331,9 @@ async function resolveDidKey(didKey: string): Promise<CryptoKey | null> {
       return null;
     }
 
-    console.error(`Unsupported multicodec prefix: 0x${codecValue.toString(16)}`);
+    console.error(
+      `Unsupported multicodec prefix: 0x${codecValue.toString(16)}`,
+    );
     return null;
   } catch (error) {
     console.error(
@@ -362,7 +364,9 @@ interface DIDDocument {
  *
  * Looks for the first assertionMethod or authentication reference.
  */
-function findDefaultVerificationMethod(didDocument: DIDDocument): string | null {
+function findDefaultVerificationMethod(
+  didDocument: DIDDocument,
+): string | null {
   // Try assertionMethod first (preferred for credentials)
   if (didDocument.assertionMethod && didDocument.assertionMethod.length > 0) {
     const am = didDocument.assertionMethod[0];
@@ -560,9 +564,7 @@ async function resolveDidWeb(didWeb: string): Promise<CryptoKey | null> {
     );
 
     if (!verificationMethod) {
-      console.error(
-        `Verification method not found: ${verificationMethodId}`,
-      );
+      console.error(`Verification method not found: ${verificationMethodId}`);
       return null;
     }
 

--- a/apps/openbadges-modular-server/tests/services/verification/proof-verifier.test.ts
+++ b/apps/openbadges-modular-server/tests/services/verification/proof-verifier.test.ts
@@ -329,8 +329,7 @@ describe("DID Key Resolution", () => {
     it("should resolve a known Ed25519 did:key", async () => {
       // Test vector from did:key spec
       // z6Mk... prefix = Ed25519
-      const didKey =
-        "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
+      const didKey = "did:key:z6MkhaXgBZDvotDkL5257faiztiGiC2QtKLGpbnnEGta2doK";
       const result = await resolveVerificationMethod(asIRI(didKey), undefined);
 
       expect(result).not.toBeNull();


### PR DESCRIPTION
## Summary

Implements DID resolution functions for proof verification that were previously stubs returning null. This enables the credential verification system to resolve public keys from `did:key` and `did:web` identifiers.

- **Implements `resolveDidKey()`** with support for Ed25519 and P-256 (secp256r1) public keys
  - Parses multibase-encoded (base58btc) public keys
  - Handles multicodec prefixes (0xed for Ed25519, 0x1200 for P-256)
  - Decompresses P-256 compressed public keys using elliptic curve math
- **Implements `resolveDidWeb()`** for fetching DID documents from web endpoints
  - Constructs HTTPS URLs from did:web identifiers
  - Validates DID document structure
  - Extracts verification methods with publicKeyJwk or publicKeyMultibase
- **Adds comprehensive tests** for DID key resolution including signature verification round-trip

## Test Plan

- [x] All existing proof-verifier tests pass (29 tests)
- [x] New tests for Ed25519 did:key resolution pass
- [x] Test for signature verification with dynamically generated Ed25519 keys
- [x] Error handling tests for unsupported multicodec, empty keys, malformed multibase
- [x] Type-check passes
- [x] Lint passes

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for did:key and did:web DID method resolution
  * Enhanced cryptographic key handling with multibase decoding and P-256 key decompression
  * Improved verification method extraction from multiple key formats

* **Tests**
  * Expanded test coverage for DID key resolution and signature verification flows
  * Added error handling tests for edge cases in key resolution

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->