### PR TITLE
feat(claude-knowledge): integrate code graph with Claude Code via skills and hooks (#435)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,7 +37,7 @@
           {
             "type": "command",
             "command": "bun \"$CLAUDE_PROJECT_DIR\"/packages/claude-knowledge/src/cli.ts graph parse \"$CLAUDE_PROJECT_DIR/packages\" --quiet",
-            "description": "Refresh code graph on session start"
+            "description": "Refresh code graph on session resume"
           }
         ]
       }

--- a/.claude/skills/graph-query/SKILL.md
+++ b/.claude/skills/graph-query/SKILL.md
@@ -32,7 +32,7 @@ bun run checkpoint graph <command> [args...]
 Parse a package directory and store the graph data:
 
 ```bash
-bun run checkpoint graph parse <package-path> [package-name]
+bun run checkpoint graph parse <package-path> [package-name] [--quiet]
 ```
 
 Example:
@@ -177,7 +177,9 @@ bun run checkpoint graph find Credential
 
 ## Output Format
 
-All commands return JSON with:
+### Query Commands
+
+Most commands (`what-calls`, `what-depends-on`, `blast-radius`, `find`, `exports`, `callers`) return JSON with:
 
 - `query`: The command type
 - `results`: Array of matching entities/relationships
@@ -191,3 +193,25 @@ Entity objects include:
 - `package`: Package containing the entity
 - `file`: File path
 - `line`: Line number (where applicable)
+
+### Parse Command
+
+The `parse` command returns a different schema:
+
+- `command`: "parse"
+- `packagePath`: Path that was parsed
+- `packageName`: Resolved package name
+- `files`: Number of files parsed
+- `entities`: Number of entities found
+- `relationships`: Number of relationships found
+- `stored`: Object with `entities` and `relationships` counts stored to database
+
+### Summary Command
+
+The `summary` command returns statistics without a `results` array:
+
+- `query`: "summary"
+- `package`: Package name or "all"
+- `totalEntities`: Total entity count
+- `totalRelationships`: Total relationship count
+- `byType`: Breakdown of entities by type

--- a/packages/claude-knowledge/src/cli/graph-commands.ts
+++ b/packages/claude-knowledge/src/cli/graph-commands.ts
@@ -47,7 +47,8 @@ export async function handleGraphCommands(
     const storeResult = storeGraph(parseResult, parseResult.package);
 
     // Always output final JSON (allows hooks to detect success/failure)
-    logger.info(
+    // Use stdout.write to avoid logger formatting that would corrupt JSON
+    process.stdout.write(
       JSON.stringify(
         {
           command: "parse",
@@ -61,7 +62,7 @@ export async function handleGraphCommands(
         },
         null,
         2,
-      ),
+      ) + "\n",
     );
   } else if (command === "what-calls") {
     // Usage: graph what-calls <name>
@@ -71,12 +72,12 @@ export async function handleGraphCommands(
     }
 
     const results = whatCalls(name);
-    logger.info(
+    process.stdout.write(
       JSON.stringify(
         { query: "what-calls", name, results, count: results.length },
         null,
         2,
-      ),
+      ) + "\n",
     );
   } else if (command === "what-depends-on") {
     // Usage: graph what-depends-on <name>
@@ -86,12 +87,12 @@ export async function handleGraphCommands(
     }
 
     const results = whatDependsOn(name);
-    logger.info(
+    process.stdout.write(
       JSON.stringify(
         { query: "what-depends-on", name, results, count: results.length },
         null,
         2,
-      ),
+      ) + "\n",
     );
   } else if (command === "blast-radius") {
     // Usage: graph blast-radius <file>
@@ -101,12 +102,12 @@ export async function handleGraphCommands(
     }
 
     const results = blastRadius(file);
-    logger.info(
+    process.stdout.write(
       JSON.stringify(
         { query: "blast-radius", file, results, count: results.length },
         null,
         2,
-      ),
+      ) + "\n",
     );
   } else if (command === "find") {
     // Usage: graph find <name> [type]
@@ -131,19 +132,19 @@ export async function handleGraphCommands(
     }
 
     const results = findEntities(name, type);
-    logger.info(
+    process.stdout.write(
       JSON.stringify(
         { query: "find", name, type, results, count: results.length },
         null,
         2,
-      ),
+      ) + "\n",
     );
   } else if (command === "exports") {
     // Usage: graph exports [package]
     const pkg = filteredArgs[0];
 
     const results = getExports(pkg);
-    logger.info(
+    process.stdout.write(
       JSON.stringify(
         {
           query: "exports",
@@ -153,14 +154,14 @@ export async function handleGraphCommands(
         },
         null,
         2,
-      ),
+      ) + "\n",
     );
   } else if (command === "summary") {
     // Usage: graph summary [package]
     const pkg = filteredArgs[0];
 
     const summary = getSummary(pkg);
-    logger.info(
+    process.stdout.write(
       JSON.stringify(
         {
           query: "summary",
@@ -169,7 +170,7 @@ export async function handleGraphCommands(
         },
         null,
         2,
-      ),
+      ) + "\n",
     );
   } else if (command === "callers") {
     // Usage: graph callers <function-name>
@@ -179,12 +180,12 @@ export async function handleGraphCommands(
     }
 
     const results = getCallers(name);
-    logger.info(
+    process.stdout.write(
       JSON.stringify(
         { query: "callers", name, results, count: results.length },
         null,
         2,
-      ),
+      ) + "\n",
     );
   } else {
     throw new Error(


### PR DESCRIPTION
## Summary

Integrates the code graph (ts-morph static analysis from #394/PR #434) with Claude Code for automatic updates and on-demand retrieval.

- Add `graph-query` skill exposing all graph CLI commands to Claude
- Add `--quiet` flag to `graph parse` for cleaner hook output
- Add SessionStart hook to auto-refresh graph on session start/resume

## Changes

### New Skill: graph-query
- `.claude/skills/graph-query/SKILL.md` - Documents all graph commands:
  - `parse` - Parse packages and store graph data
  - `what-calls` - Find function callers
  - `callers` - Find direct callers
  - `what-depends-on` - Find dependencies
  - `blast-radius` - Find transitive impact
  - `find` - Search entities by name/type
  - `exports` - List package exports
  - `summary` - Show statistics

### CLI Enhancement
- `packages/claude-knowledge/src/cli/graph-commands.ts` - Add `--quiet` flag to suppress verbose progress messages while preserving final JSON output

### SessionStart Hook
- `.claude/settings.json` - Add hook to parse all packages on session start/resume

## Test plan

- [x] Manual: Verify skill file loads in Claude Code
- [x] Manual: Test `--quiet` flag suppresses progress messages
- [x] Manual: Test graph commands work via skill
- [x] Type-check passes
- [x] Tests pass (322 pass, 0 fail in claude-knowledge)

Closes #435

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code graph now automatically refreshes on session start for up-to-date analysis
  * Graph commands support a new --quiet flag to suppress verbose output

* **Documentation**
  * Added Graph Query Skill documentation with command syntax, examples, and impact analysis workflows

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->