### PR TITLE
chore(claude-knowledge): bootstrap documentation index (#467)

### DIFF
--- a/packages/claude-knowledge/docs/DOC-MAINTENANCE.md
+++ b/packages/claude-knowledge/docs/DOC-MAINTENANCE.md
@@ -77,7 +77,7 @@ The script automatically skips:
 
 ### Output Example
 
-```
+```text
 🟢  INFO  Starting documentation bootstrap...
 🟢  INFO  [Priority 1] Indexing root context files...
 🟢  INFO  Indexed: CLAUDE.md (9 sections)
@@ -95,7 +95,7 @@ The script automatically skips:
 
 ### Incremental Re-index Example
 
-```
+```text
 🟢  INFO  Starting documentation bootstrap...
 🟢  INFO  [Priority 1] Indexing root context files...
 🟢  INFO  Skipped (unchanged): CLAUDE.md
@@ -135,7 +135,7 @@ bun run checkpoint docs search "development workflow gates"
 
 ### Search Results Format
 
-```
+```text
 ## Section Heading
    Location: /path/to/file.md#anchor
    Similarity: 72.8%


### PR DESCRIPTION
## Summary

- Add `bootstrap-docs.ts` script to index monorepo documentation into the claude-knowledge system
- Create `DOC-MAINTENANCE.md` guide documenting the manual periodic re-index maintenance strategy
- Index 30 documentation files creating 654 searchable doc sections

## Changes

### New Files
- `packages/claude-knowledge/scripts/bootstrap-docs.ts` - Bootstrap script that indexes docs in priority order:
  1. Root `CLAUDE.md` and `README.md`
  2. `docs/*.md` (monorepo docs)
  3. `packages/*/CLAUDE.md` (package context)
  4. `packages/*/docs/*.md` (package docs)

- `packages/claude-knowledge/docs/DOC-MAINTENANCE.md` - Maintenance guide documenting:
  - When and how to re-index
  - Search usage patterns
  - Troubleshooting guide
  - Alternative strategies comparison

## Test plan

- [x] Type-check passes
- [x] Lint passes (no new warnings)
- [x] Tests pass
- [x] Build succeeds
- [x] Bootstrap script runs successfully
- [x] Search queries return relevant results:
  - `bun run checkpoint docs search "how does checkpoint work?"` ✓
  - `bun run checkpoint docs search "Open Badges"` ✓
- [x] Incremental re-index works (skips unchanged files, completes in ~100ms)

## Review Notes

Code review found no critical or high-priority issues. One medium-priority UX suggestion (special warning for Priority 1 file failures) was noted but not blocking.

Closes #467

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive maintenance guide for documentation management, covering indexing procedures, search functionality, troubleshooting strategies, and bootstrap workflows with command examples and best practices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->