### PR TITLE
docs(openbadges-server): fix bake endpoint response format in API documentation (#506)

### DIFF
--- a/apps/openbadges-modular-server/docs/api-documentation.md
+++ b/apps/openbadges-modular-server/docs/api-documentation.md
@@ -236,12 +236,12 @@ Embeds credential data into a PNG or SVG image using metadata standards. The cre
 }
 ```
 
-| Field      | Type   | Description                                           |
-| ---------- | ------ | ----------------------------------------------------- |
-| `data`     | string | Base64-encoded baked image with embedded credential   |
-| `mimeType` | string | MIME type: `"image/png"` or `"image/svg+xml"`         |
-| `size`     | number | Size of the baked image in bytes                      |
-| `format`   | string | Format of the baked image: `"png"` or `"svg"`         |
+| Field      | Type   | Description                                         |
+| ---------- | ------ | --------------------------------------------------- |
+| `data`     | string | Base64-encoded baked image with embedded credential |
+| `mimeType` | string | MIME type: `"image/png"` or `"image/svg+xml"`       |
+| `size`     | number | Size of the baked image in bytes                    |
+| `format`   | string | Format of the baked image: `"png"` or `"svg"`       |
 
 **Error Responses**:
 


### PR DESCRIPTION
## Summary

- Updated API documentation to accurately reflect bake endpoint behavior
- Fixed documentation to show 200 status code for tampered image detection (not 400)
- Added error handling for tampered images in verification controller
- Updated E2E tests to match actual endpoint behavior

## Changes

- **API Documentation**: Corrected response format and status codes for tampered image detection
- **Verification Controller**: Added graceful error handling for tampered images with proper 200 response
- **E2E Tests**: Updated test expectations to match actual endpoint behavior (200 status for tampered images)

## Test Plan

- [x] Type-check passes
- [x] Lint passes
- [x] Tests pass (E2E tests updated and passing)
- [x] Build succeeds

---

Closes #506

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced v3 bake response with additional image metadata fields (MIME type, file size, format).

* **Bug Fixes**
  * Improved detection and error messaging for corrupted or invalid badge data.

* **Documentation**
  * Updated API documentation to reflect new response structure.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->