### PR TITLE
chore(shared-config): replace echo scripts with exit 0

### DIFF
--- a/packages/shared-config/package.json
+++ b/packages/shared-config/package.json
@@ -14,11 +14,11 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write '*.{js,mjs,json}'",
     "format:check": "prettier --check '*.{js,mjs,json}'",
-    "test": "echo 'No tests for shared-config'",
-    "test:unit": "echo 'No tests for shared-config'",
-    "test:integration": "echo 'No tests for shared-config'",
-    "test:e2e": "echo 'No tests for shared-config'",
-    "type-check": "echo 'No types to check'"
+    "test": "exit 0",
+    "test:unit": "exit 0",
+    "test:integration": "exit 0",
+    "test:e2e": "exit 0",
+    "type-check": "exit 0"
   },
   "files": [
     "eslint.config.mjs",


### PR DESCRIPTION
## Summary
- Replace placeholder echo scripts with silent `exit 0` for proper no-op handling
- Reduces CI noise and improves Turbo caching behavior
- Follows standard shell convention for "no operation needed"

## Changes
- `packages/shared-config/package.json`: Replace 5 echo statements with `exit 0`

## Test plan
- [x] Scripts execute with exit code 0
- [x] Turbo caching works correctly
- [x] Full monorepo type-check passes

Closes #194

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test and type-check scripts to ensure consistent successful exit status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->