### PR TITLE
test(openbadges-modular-server): add PostgreSQL API Key repository tests

### DIFF
--- a/apps/openbadges-modular-server/tests/infrastructure/database/modules/postgresql/repositories/postgres-api-key.repository.test.ts
+++ b/apps/openbadges-modular-server/tests/infrastructure/database/modules/postgresql/repositories/postgres-api-key.repository.test.ts
@@ -100,7 +100,8 @@ const runTests = await isDatabaseAvailable();
   });
 
   it("should return null when finding a non-existent API key by ID", async () => {
-    const nonExistentId = "urn:uuid:00000000-0000-0000-0000-000000000000" as Shared.IRI;
+    const nonExistentId =
+      "urn:uuid:00000000-0000-0000-0000-000000000000" as Shared.IRI;
     const foundApiKey = await repository.findById(nonExistentId);
 
     expect(foundApiKey).toBeNull();
@@ -199,11 +200,15 @@ const runTests = await isDatabaseAvailable();
     expect(updatedApiKey?.id).toBe(createdApiKey.id);
     expect(updatedApiKey?.name).toBe("Updated Name");
     expect(updatedApiKey?.description).toBe("Updated description");
-    expect(updatedApiKey?.permissions).toEqual({ roles: ["user"], scope: "read-only" });
+    expect(updatedApiKey?.permissions).toEqual({
+      roles: ["user"],
+      scope: "read-only",
+    });
   });
 
   it("should return null when updating a non-existent API key", async () => {
-    const nonExistentId = "urn:uuid:00000000-0000-0000-0000-000000000000" as Shared.IRI;
+    const nonExistentId =
+      "urn:uuid:00000000-0000-0000-0000-000000000000" as Shared.IRI;
     const updatedApiKey = await repository.update(nonExistentId, {
       name: "Updated Name",
     });
@@ -228,7 +233,8 @@ const runTests = await isDatabaseAvailable();
   });
 
   it("should return false when deleting a non-existent API key", async () => {
-    const nonExistentId = "urn:uuid:00000000-0000-0000-0000-000000000000" as Shared.IRI;
+    const nonExistentId =
+      "urn:uuid:00000000-0000-0000-0000-000000000000" as Shared.IRI;
     const deleted = await repository.delete(nonExistentId);
 
     expect(deleted).toBe(false);
@@ -251,7 +257,8 @@ const runTests = await isDatabaseAvailable();
   });
 
   it("should return null when revoking a non-existent API key", async () => {
-    const nonExistentId = "urn:uuid:00000000-0000-0000-0000-000000000000" as Shared.IRI;
+    const nonExistentId =
+      "urn:uuid:00000000-0000-0000-0000-000000000000" as Shared.IRI;
     const revokedApiKey = await repository.revoke(nonExistentId);
 
     expect(revokedApiKey).toBeNull();
@@ -275,7 +282,8 @@ const runTests = await isDatabaseAvailable();
   });
 
   it("should return null when updating last used for a non-existent API key", async () => {
-    const nonExistentId = "urn:uuid:00000000-0000-0000-0000-000000000000" as Shared.IRI;
+    const nonExistentId =
+      "urn:uuid:00000000-0000-0000-0000-000000000000" as Shared.IRI;
     const updatedApiKey = await repository.updateLastUsed(nonExistentId);
 
     expect(updatedApiKey).toBeNull();


### PR DESCRIPTION
## Summary

- Add comprehensive unit tests for `PostgresApiKeyRepository` covering all 9 repository methods
- Repository implementation was already complete (not a stub as issue indicated)
- Tests use the existing postgres-test-helper infrastructure
- Tests automatically skip when PostgreSQL is not available

## Test Coverage

| Method | Test Coverage |
|--------|--------------|
| create | ✅ |
| findById | ✅ (+ null case) |
| findByKey | ✅ (+ null case) |
| findByUserId | ✅ (+ empty case) |
| findAll | ✅ |
| update | ✅ (+ null case) |
| delete | ✅ (+ false case) |
| revoke | ✅ (+ null case) |
| updateLastUsed | ✅ (+ null case) |

## Acceptance Criteria

- [x] ~~Create `postgres-api-key.mapper.ts`~~ (inline `toDomain` method exists)
- [x] Implement all 9 repository methods (**already done**)
- [x] Remove unreachable catch blocks (**already done**)
- [x] Add unit tests for the repository
- [x] `bun run lint` passes

Closes #165

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for API key repository operations, including creation, retrieval, updating, deletion, revocation, and timestamp management functionality.

**Note:** This release contains no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->