### PR TITLE
feat(openbadges-ui): add modern exports field to package.json

### DIFF
--- a/packages/openbadges-ui/package.json
+++ b/packages/openbadges-ui/package.json
@@ -6,6 +6,16 @@
   "main": "dist/openbadges-ui.umd.js",
   "module": "dist/openbadges-ui.es.js",
   "types": "dist/types/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/types/src/index.d.ts",
+      "import": "./dist/openbadges-ui.es.js",
+      "require": "./dist/openbadges-ui.umd.js"
+    },
+    "./styles": {
+      "import": "./dist/style.css"
+    }
+  },
   "files": [
     "dist",
     "src"


### PR DESCRIPTION
## Summary

Adds modern `exports` field to openbadges-ui package.json for proper subpath imports support.

## Changes

```json
"exports": {
  ".": {
    "types": "./dist/types/src/index.d.ts",
    "import": "./dist/openbadges-ui.es.js",
    "require": "./dist/openbadges-ui.umd.js"
  },
  "./styles": {
    "import": "./dist/style.css"
  }
}
```

## Benefits

- Modern tooling support
- Better tree-shaking
- Enables "Are the Types Wrong" validation (already used in openbadges-types)
- Allows importing styles separately: `import 'openbadges-ui/styles'`

## Test plan

- [x] Build succeeds
- [x] No new type errors introduced (pre-existing vue-tsc errors unrelated)

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package exports configuration to enable modular import paths, including separate stylesheet imports and enhanced TypeScript type definition support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->