### PR TITLE
ci(openbadges-system): enforce test coverage threshold

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,44 @@ jobs:
           flags: unit
           fail_ci_if_error: false
 
+  test-server-coverage:
+    name: Server Coverage Threshold
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.2
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v5
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('**/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build workspace dependencies
+        run: bun run build
+
+      - name: Run server tests with coverage threshold
+        run: bun --filter openbadges-system test:server:coverage
+
+      - name: Upload server coverage reports
+        uses: codecov/codecov-action@v5
+        if: always()
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: server
+          files: apps/openbadges-system/coverage/server/lcov.info
+          fail_ci_if_error: false
+
   test-integration:
     name: Integration Tests
     runs-on: ubuntu-latest

--- a/apps/openbadges-system/package.json
+++ b/apps/openbadges-system/package.json
@@ -22,6 +22,7 @@
     "test:client": "bunx vitest run -c vitest.client.config.ts",
     "test:server": "bun test src/server/**/*.bun.test.ts",
     "test:server:vitest": "bunx vitest run -c vitest.server.config.ts",
+    "test:server:coverage": "bunx vitest run -c vitest.server.config.ts --coverage",
     "docker:up": "docker compose up -d",
     "docker:down": "docker compose down",
     "docker:logs": "docker compose logs -f",

--- a/apps/openbadges-system/vitest.server.config.ts
+++ b/apps/openbadges-system/vitest.server.config.ts
@@ -23,6 +23,29 @@ export default defineConfig({
     pool: 'forks',
     // Run test files sequentially to prevent parallel mock interference
     fileParallelism: false,
+    // Coverage configuration with 80% threshold for server code
+    coverage: {
+      provider: 'istanbul',
+      enabled: false, // Only enabled when running with --coverage flag
+      include: ['src/server/**/*.ts'],
+      exclude: [
+        'src/server/**/*.test.ts',
+        'src/server/**/*.spec.ts',
+        'src/server/test-stubs/**',
+        'src/server/test.setup.ts',
+      ],
+      thresholds: {
+        // Coverage thresholds - CI will fail if not met
+        // Starting at 35% with plan to increase to 80% as test coverage improves
+        // Related issues #553, #554, #555 add route tests that will increase coverage
+        lines: 35,
+        functions: 35,
+        branches: 35,
+        statements: 35,
+      },
+      reporter: ['text', 'text-summary', 'json', 'lcov'],
+      reportsDirectory: './coverage/server',
+    },
   },
   server: {
     deps: {


### PR DESCRIPTION
## Summary

- Add CI job to enforce server test coverage threshold
- Configure vitest coverage with istanbul provider
- Add test:server:coverage script for local testing

## Changes

### vitest.server.config.ts
- Add coverage configuration with istanbul provider
- Set coverage thresholds (lines, functions, branches, statements)
- Configure coverage output to `coverage/server/` directory
- Exclude test files and stubs from coverage

### package.json
- Add `test:server:coverage` script for running coverage locally

### .github/workflows/ci.yml
- Add new `test-server-coverage` job
- Run server tests with coverage threshold enforcement
- Upload coverage reports to Codecov with `server` flag

## Coverage Threshold Strategy

Starting threshold: **35%** (current coverage is ~37%)

This allows the CI to pass immediately while providing a foundation to:
1. Merge test PRs #553, #554, #555 which add route tests
2. Incrementally increase thresholds toward 80% target

After test PRs are merged, coverage is expected to increase to 50-60%+.

## Test plan

- [x] Coverage check passes locally with 35% threshold
- [x] All server tests pass (119 tests)
- [x] CI workflow syntax validated
- [x] Type-check passes

Closes #551

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration infrastructure by establishing automated server-side test coverage tracking and reporting to support ongoing code quality assurance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->