### PR TITLE
fix(claude-knowledge): use absolute paths for Vue file mapping

### DIFF
--- a/packages/claude-knowledge/src/graph/parser.test.ts
+++ b/packages/claude-knowledge/src/graph/parser.test.ts
@@ -739,5 +739,21 @@ export function oldGreet(): string {
       expect(formatDateFn).toBeDefined();
       expect(formatDateFn?.filePath).toBe("component.vue");
     });
+
+    it("parsePackage uses original .vue paths, not virtual .vue.ts paths", () => {
+      const result = parsePackage(FIXTURES_DIR, "test-pkg");
+
+      // No entity should have .vue.ts in the path (that's the virtual path)
+      const virtualPathEntities = result.entities.filter((e) =>
+        e.filePath.includes(".vue.ts"),
+      );
+      expect(virtualPathEntities.length).toBe(0);
+
+      // No relationship should reference .vue.ts paths
+      const virtualPathRelationships = result.relationships.filter(
+        (r) => r.from.includes(".vue.ts") || r.to.includes(".vue.ts"),
+      );
+      expect(virtualPathRelationships.length).toBe(0);
+    });
   });
 });

--- a/packages/claude-knowledge/src/graph/parser.ts
+++ b/packages/claude-knowledge/src/graph/parser.ts
@@ -8,7 +8,7 @@
 import { Project, SyntaxKind } from "ts-morph";
 import type { SourceFile, Node, JSDoc } from "ts-morph";
 import { readdirSync, statSync, readFileSync } from "fs";
-import { join, relative, dirname } from "path";
+import { join, relative, dirname, resolve } from "path";
 import { defaultLogger as logger } from "@rollercoaster-dev/rd-logger";
 import { parse as parseVueSFC } from "@vue/compiler-sfc";
 import type {
@@ -913,7 +913,9 @@ export function parsePackage(
         const vueScript = extractVueScript(file);
         if (vueScript) {
           // Create virtual TypeScript file for ts-morph
-          const virtualPath = `${file}.ts`;
+          // Use absolute path so it matches sourceFile.getFilePath()
+          const absoluteFile = resolve(file);
+          const virtualPath = `${absoluteFile}.ts`;
           project.createSourceFile(virtualPath, vueScript.content);
           vueFileMapping.set(virtualPath, relative(packagePath, file));
           vueFilesProcessed++;


### PR DESCRIPTION
## Summary

- Fix Vue file path mapping in graph parser - entities were showing `.vue.ts` instead of `.vue`
- The virtual path stored in `vueFileMapping` was relative, but `sourceFile.getFilePath()` returns absolute paths, causing lookup failures
- Added test to catch this regression

## Test plan

- [x] Run `bun test src/graph/parser.test.ts` - all 35 tests pass
- [x] Parse openbadges-ui and verify Vue files have correct `.vue` paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Vue Single File Component parsing to correctly preserve original .vue file paths instead of virtual paths, ensuring accurate component references throughout the system.

* **Tests**
  * Added comprehensive test coverage to verify original Vue component file paths are maintained during parsing and relationship mapping.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->