### PR TITLE
feat(claude-knowledge): add Grep augmentation hook and fix metrics tracking

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,5 +1,18 @@
 {
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun \"$CLAUDE_PROJECT_DIR\"/.claude/hooks/pretooluse-gate.ts",
+            "timeout": 5000,
+            "description": "Augment Grep with graph_find results + log metrics"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": "startup",

--- a/packages/claude-knowledge/src/cli/session-commands.ts
+++ b/packages/claude-knowledge/src/cli/session-commands.ts
@@ -146,8 +146,10 @@ export async function handleSessionStart(args: string[]): Promise<void> {
     });
   }
 
-  // Output the summary (for injection into context)
-  console.log(context.summary);
+  // Knowledge injection disabled - learnings are queried on-demand via MCP tools
+  // See: https://github.com/rollercoaster-dev/monorepo - session discussing Beads vs claude-knowledge
+  // The session-start context is too early (we don't know what we'll work on yet)
+  // console.log(context.summary);
 
   // Output session metadata for session-end to consume
   // This is output as a special marker that can be captured


### PR DESCRIPTION
## Summary

- **Grep augmentation hook**: When Claude calls Grep with an identifier-like pattern (camelCase, PascalCase, snake_case), the PreToolUse hook automatically runs `graph.findEntities()` and shows results. This provides passive knowledge injection - Claude sees graph results without having to remember to use graph tools.

- **Disabled session-start knowledge injection**: The injection happened before we knew the session topic, making injected learnings essentially random. On-demand MCP tool queries are more useful.

- **Fixed metrics aggregation**: `getToolUsageAggregate()` now includes both `tool_usage` table (native tools via PreToolUse) and `graph_queries` table (MCP graph tools). Previously showed ratio of 0; actual ratio is ~0.53.

## Key Insight

Fighting training with rules doesn't work. Passive augmentation that adds information without blocking is more effective than expecting Claude to remember to use specific tools.

## Test plan

- [ ] Start new session and call Grep with an identifier pattern (e.g., `handleSessionStart`)
- [ ] Verify graph augmentation appears in hook output
- [ ] Check `metrics_get_tool_usage_aggregate` shows non-zero graph count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Search results now augmented with graph context when using the Grep tool, improving discoverability.

* **Refactor**
  * Metrics aggregation enhanced to combine data from multiple sources for comprehensive tool usage reporting.

* **Chores**
  * Updated tool hook configuration to enable graph augmentation capabilities.
  * Adjusted session initialization to remove redundant context output.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->