### PR TITLE
fix(openbadges-server): skip issuer DID resolution in verify unit tests

### DIFF
--- a/apps/openbadges-modular-server/tests/api/verify.test.ts
+++ b/apps/openbadges-modular-server/tests/api/verify.test.ts
@@ -427,6 +427,7 @@ describe("Verify Credential Endpoint", () => {
               proofValue: "test-proof-value",
             },
           },
+          options: { skipIssuerVerification: true },
         };
 
         const result = await controller.verifyCredential(request);
@@ -451,6 +452,7 @@ describe("Verify Credential Endpoint", () => {
             type: ["VerifiableCredential"],
             issuanceDate: "2024-01-01T00:00:00Z",
           },
+          options: { skipIssuerVerification: true },
         };
 
         const result = await controller.verifyCredential(request);
@@ -468,6 +470,7 @@ describe("Verify Credential Endpoint", () => {
             issuer: "did:web:example.com",
             issuanceDate: "2024-01-01T00:00:00Z",
           },
+          options: { skipIssuerVerification: true },
         };
 
         const result = await controller.verifyCredential(request);
@@ -491,6 +494,7 @@ describe("Verify Credential Endpoint", () => {
           },
           options: {
             skipTemporalValidation: true, // Should skip the future issuance date check
+            skipIssuerVerification: true,
           },
         };
 
@@ -524,6 +528,7 @@ describe("Verify Credential Endpoint", () => {
 
         const request = {
           credential: jwt,
+          options: { skipIssuerVerification: true },
         };
 
         const result = await controller.verifyCredential(request);
@@ -536,6 +541,7 @@ describe("Verify Credential Endpoint", () => {
       it("should reject invalid JWT format", async () => {
         const request = {
           credential: "invalid.jwt.format.with.four.parts",
+          options: { skipIssuerVerification: true },
         };
 
         const result = await controller.verifyCredential(request);
@@ -561,6 +567,7 @@ describe("Verify Credential Endpoint", () => {
               verificationMethod: "did:web:example.com#key-1",
             },
           },
+          options: { skipIssuerVerification: true },
         };
 
         const result = await controller.verifyCredential(request);
@@ -590,6 +597,7 @@ describe("Verify Credential Endpoint", () => {
           },
           options: {
             allowExpired: true,
+            skipIssuerVerification: true,
           },
         };
 
@@ -614,6 +622,7 @@ describe("Verify Credential Endpoint", () => {
               verificationMethod: "did:web:example.com#key-1",
             },
           },
+          options: { skipIssuerVerification: true },
         };
 
         const result = await controller.verifyCredential(request);
@@ -650,6 +659,7 @@ describe("Verify Credential Endpoint", () => {
               proofValue: "test-proof-value",
             },
           },
+          options: { skipIssuerVerification: true },
         };
 
         const result = await controller.verifyCredential(request);
@@ -676,6 +686,7 @@ describe("Verify Credential Endpoint", () => {
               proofValue: "test-proof-value",
             },
           },
+          options: { skipIssuerVerification: true },
         };
 
         const result = await controller.verifyCredential(request);
@@ -701,6 +712,7 @@ describe("Verify Credential Endpoint", () => {
               proofValue: "test-proof-value",
             },
           },
+          options: { skipIssuerVerification: true },
         };
 
         const result = await controller.verifyCredential(request);
@@ -726,6 +738,7 @@ describe("Verify Credential Endpoint", () => {
               proofValue: "test-proof-value",
             },
           },
+          options: { skipIssuerVerification: true },
         };
 
         const result = await controller.verifyCredential(request);
@@ -751,6 +764,7 @@ describe("Verify Credential Endpoint", () => {
               proofValue: "test-proof-value",
             },
           },
+          options: { skipIssuerVerification: true },
         };
 
         const result = await controller.verifyCredential(request);
@@ -775,6 +789,7 @@ describe("Verify Credential Endpoint", () => {
               proofValue: "test-proof-value",
             },
           },
+          options: { skipIssuerVerification: true },
         };
 
         const result = await controller.verifyCredential(request);
@@ -796,6 +811,7 @@ describe("Verify Credential Endpoint", () => {
               verificationMethod: "did:web:example.com#key-1",
             },
           },
+          options: { skipIssuerVerification: true },
         };
 
         const result = await controller.verifyCredential(request);


### PR DESCRIPTION
## Summary

- Add `skipIssuerVerification: true` to all 16 `VerificationController` unit tests that call `verifyCredential()` with `did:web:example.com` as issuer
- This prevents network calls to `https://example.com/.well-known/did.json` for DID resolution that hang in CI

## Context

The verify tests were hanging for 13+ minutes in CI because `verifyIssuer("did:web:example.com")` makes HTTP requests to resolve the DID document. In CI environments with restricted/slow networking, these `fetch()` calls never complete.

The test file's own JSDoc comment (lines 7-9) already documented the fix:
> To avoid network calls for DID resolution in tests, use `options: { skipIssuerVerification: true }`

But none of the tests actually used this option. These tests are testing credential structure validation, temporal checks, proof type handling, and cryptosuite validation — not issuer DID resolution.

## Test plan

- [x] All 44 verify tests pass locally (165ms total)
- [ ] CI Unit Tests complete without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced credential verification tests to support optional issuer verification bypass option, reducing reliance on external dependencies and enabling tests to execute independently without network calls. Updates comprehensively cover JSON-LD and JWT credential verification scenarios, including edge cases such as expiration handling, invalid formats, and cryptosuite validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->