### PR TITLE
fix(openbadges-system): add Authorization header to useUsers API calls (#769)

### DIFF
--- a/apps/openbadges-system/src/client/composables/useUsers.ts
+++ b/apps/openbadges-system/src/client/composables/useUsers.ts
@@ -91,13 +91,14 @@ export const useUsers = () => {
   // eslint-disable-next-line no-undef
   const apiCall = async (endpoint: string, options: RequestInit = {}) => {
     const token = typeof window !== 'undefined' ? localStorage.getItem('auth_token') : null
+    const { headers: optionHeaders, ...restOptions } = options
     const response = await fetch(`/api/bs${endpoint}`, {
       headers: {
         'Content-Type': 'application/json',
         ...(token && { Authorization: `Bearer ${token}` }),
-        ...options.headers,
+        ...optionHeaders,
       },
-      ...options,
+      ...restOptions,
     })
 
     if (!response.ok) {


### PR DESCRIPTION
## Summary

- Adds missing `Authorization: Bearer <token>` header to the `useUsers` composable's `apiCall` function and `exportUsers` function
- Fixes 401 errors on all user management API calls (list, create, update, delete, export)
- Includes SSR guard (`typeof window !== 'undefined'`) consistent with `badgeApi.ts` pattern

## Changes

- **useUsers.ts**: Read token from `localStorage` with SSR guard, conditionally spread `Authorization` header into `apiCall` and `exportUsers` fetch requests

## Test Plan

- [x] Type-check passes
- [x] Lint passes (0 errors)
- [x] All 125 client tests pass
- [x] Code review: approved, no critical issues
- [x] Silent failure audit: SSR guard finding addressed

---

Closes #769

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API request authentication to ensure proper authorization headers are included across all API calls, including user export operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->