### PR TITLE
fix(ci): use CHANGESETS_TOKEN for checkout to trigger CI on version PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          token: ${{ secrets.CHANGESETS_TOKEN }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary
- Pass `CHANGESETS_TOKEN` to `actions/checkout` in the release workflow so git push uses it instead of the default `GITHUB_TOKEN`
- Fixes CI not triggering on the `changeset-release/main` branch after the changesets action force-pushes — GitHub's anti-recursion rule blocks workflow triggers from `github-actions[bot]` (default token)

## Test plan
- [ ] Merge this PR, then merge another PR with a changeset
- [ ] Verify CI runs on PR #816 (`changeset-release/main`) after the release workflow updates it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow configuration to enhance authentication handling during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->