### PR TITLE
fix(ci): prep sources for upcoming dependency bumps

### DIFF
--- a/apps/native-rd/src/components/Confetti/__tests__/Confetti.test.tsx
+++ b/apps/native-rd/src/components/Confetti/__tests__/Confetti.test.tsx
@@ -51,10 +51,12 @@ describe("Confetti", () => {
     const { toJSON } = render(<Confetti visible={true} />);
     const tree = toJSON();
     expect(tree).not.toBeNull();
+    if (!tree || Array.isArray(tree))
+      throw new Error("expected single root node");
     // Container should have children (confetti pieces)
-    expect(tree?.type).toBe("View");
-    expect(tree?.children).not.toBeNull();
-    expect(tree?.children?.length).toBe(60);
+    expect(tree.type).toBe("View");
+    expect(tree.children).not.toBeNull();
+    expect(tree.children?.length).toBe(60);
   });
 
   it("calls onComplete after cleanup timeout", () => {
@@ -80,9 +82,10 @@ describe("Confetti", () => {
 
   it("marks confetti as hidden from accessibility", () => {
     const { toJSON } = render(<Confetti visible={true} />);
-    expect(toJSON()?.props.accessibilityElementsHidden).toBe(true);
-    expect(toJSON()?.props.importantForAccessibility).toBe(
-      "no-hide-descendants",
-    );
+    const tree = toJSON();
+    if (!tree || Array.isArray(tree))
+      throw new Error("expected single root node");
+    expect(tree.props.accessibilityElementsHidden).toBe(true);
+    expect(tree.props.importantForAccessibility).toBe("no-hide-descendants");
   });
 });

--- a/apps/native-rd/src/hooks/__tests__/useFlashOnIncrease.test.ts
+++ b/apps/native-rd/src/hooks/__tests__/useFlashOnIncrease.test.ts
@@ -17,7 +17,7 @@ jest.mock("react-native-reanimated", () => {
       sharedVal = { value: initial };
       return sharedVal;
     },
-    useAnimatedStyle: (fn: () => object) => fn(),
+    useAnimatedStyle: <T>(fn: () => T): T => fn(),
     withSequence: (...args: unknown[]) => args[args.length - 1],
     withTiming: (val: number) => val,
   };
@@ -31,6 +31,8 @@ describe("useFlashOnIncrease", () => {
 
   it("starts with zero opacity", () => {
     const { result } = renderHook(() => useFlashOnIncrease(0));
+    // result.current types as AnimatedStyleHandle<{opacity}>; the real type is
+    // opaque in reanimated v4+, but the mock returns a plain object.
     const style = result.current as unknown as { opacity: number };
     expect(style.opacity).toBe(0);
   });

--- a/apps/native-rd/src/hooks/__tests__/useFlashOnIncrease.test.ts
+++ b/apps/native-rd/src/hooks/__tests__/useFlashOnIncrease.test.ts
@@ -31,6 +31,7 @@ describe("useFlashOnIncrease", () => {
 
   it("starts with zero opacity", () => {
     const { result } = renderHook(() => useFlashOnIncrease(0));
-    expect(result.current.opacity).toBe(0);
+    const style = result.current as unknown as { opacity: number };
+    expect(style.opacity).toBe(0);
   });
 });

--- a/apps/native-rd/tsconfig.json
+++ b/apps/native-rd/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }

--- a/apps/openbadges-modular-server/tsconfig.json
+++ b/apps/openbadges-modular-server/tsconfig.json
@@ -20,17 +20,16 @@
     "verbatimModuleSyntax": false,
     "emitDeclarationOnly": true,
 
-    /* Path Aliases */
-    "baseUrl": ".",
+    /* Path Aliases (resolved relative to this tsconfig) */
     "paths": {
-      "@/*": ["src/*"],
-      "@core/*": ["src/core/*"],
-      "@domains/*": ["src/domains/*"],
-      "@infrastructure/*": ["src/infrastructure/*"],
-      "@utils/*": ["src/utils/*"],
-      "@config/*": ["src/config/*"],
-      "@types/*": ["src/types/*"],
-      "@tests/*": ["tests/*"]
+      "@/*": ["./src/*"],
+      "@core/*": ["./src/core/*"],
+      "@domains/*": ["./src/domains/*"],
+      "@infrastructure/*": ["./src/infrastructure/*"],
+      "@utils/*": ["./src/utils/*"],
+      "@config/*": ["./src/config/*"],
+      "@types/*": ["./src/types/*"],
+      "@tests/*": ["./tests/*"]
     },
 
     /* Override shared-config's strict mode for gradual migration */

--- a/apps/openbadges-system/eslint.config.mjs
+++ b/apps/openbadges-system/eslint.config.mjs
@@ -148,8 +148,6 @@ export default [
       // Disable no-undef for Vue files — TypeScript handles this more accurately,
       // and vue-eslint-parser doesn't recognize custom compiler macros like definePage
       'no-undef': 'off',
-      // Disable deprecated rule, use vue/block-order instead
-      'vue/component-tags-order': 'off',
       // Script-first order matches Prettier and Vue 3 Composition API convention
       'vue/block-order': [
         'error',

--- a/apps/openbadges-system/tsconfig.json
+++ b/apps/openbadges-system/tsconfig.json
@@ -25,11 +25,10 @@
     /* Vite-specific types + Bun for server code */
     "types": ["unplugin-vue-router/client", "vite/client", "bun"],
 
-    /* Path aliases */
-    "baseUrl": ".",
+    /* Path aliases (resolved relative to this tsconfig) */
     "paths": {
-      "@/*": ["src/client/*"],
-      "@server/*": ["src/server/*"]
+      "@/*": ["./src/client/*"],
+      "@server/*": ["./src/server/*"]
     },
 
     /* Disable unused vars checking (handled by ESLint) */

--- a/packages/openbadges-ui/tsconfig.json
+++ b/packages/openbadges-ui/tsconfig.json
@@ -6,15 +6,14 @@
     "allowJs": true,
     "jsx": "preserve",
 
-    /* Path aliases for cleaner imports */
-    "baseUrl": ".",
+    /* Path aliases for cleaner imports (resolved relative to this tsconfig) */
     "paths": {
-      "@/*": ["src/*"],
-      "@components/*": ["src/components/*"],
-      "@composables/*": ["src/composables/*"],
-      "@services/*": ["src/services/*"],
-      "@utils/*": ["src/utils/*"],
-      "@types/*": ["src/types/*"]
+      "@/*": ["./src/*"],
+      "@components/*": ["./src/components/*"],
+      "@composables/*": ["./src/composables/*"],
+      "@services/*": ["./src/services/*"],
+      "@utils/*": ["./src/utils/*"],
+      "@types/*": ["./src/types/*"]
     },
 
     /* Override shared-config for declaration output */

--- a/packages/shared-config/eslint.config.mjs
+++ b/packages/shared-config/eslint.config.mjs
@@ -116,7 +116,7 @@ export const vue = [
       'vue/require-prop-types': 'error',
       'vue/no-unused-components': 'error',
       'vue/no-v-html': 'warn',
-      'vue/component-tags-order': ['error', { order: ['script', 'template', 'style'] }],
+      'vue/block-order': ['error', { order: ['script', 'template', 'style'] }],
       'vue/multi-word-component-names': 'off',
 
       // Disable base rule in favor of TypeScript version


### PR DESCRIPTION
## Summary

Unblocks the stalled dependabot PRs (#917 dev-deps, #918 prod-deps) by adapting the source tree to upcoming breaking changes in our deps. All changes are backwards-compatible with the versions currently on `main`.

- **`shared-config/eslint.config.mjs`**: rename `vue/component-tags-order` → `vue/block-order`. The former is removed in `eslint-plugin-vue` v10; the latter has existed as a drop-in alias since v9.16, so this works against our current `^9.32.0` too.
- **tsconfigs** (`openbadges-ui`, `native-rd`, `openbadges-system`, `openbadges-modular-server`): drop deprecated `baseUrl` (TS 5101 in TS 6.x) and prefix each `paths` entry with `./` so they resolve relative to the tsconfig dir — TS 5+ behavior.
- **`Confetti.test.tsx`**: narrow `toJSON()` against the newer, tighter `ReactTestRendererJSON | ReactTestRendererJSON[] | null` union so the `.type` / `.children` / `.props` access type-checks against the bumped `@types/react-test-renderer`.
- **`useFlashOnIncrease.test.ts`**: cast hook result through `unknown` since the newer `react-native-reanimated` `AnimatedStyleHandle` no longer exposes inner style fields directly.

Deliberately **not** included: Zod v4 schema test fixes from the dependabot PRs — those are coupled to the Zod bump itself and should land with it.

## Test plan

- [x] `bun run lint` — clean (warnings only, no errors)
- [x] `bun run type-check` — all 9 packages pass
- [x] `bun run test --testPathPatterns "Confetti|useFlashOnIncrease"` in `apps/native-rd` — 8/8 pass
- [ ] Once merged: comment `@dependabot rebase` on #917 and #918; expect only the Zod-related unit test failures to remain on #918 and the `baseUrl`/test failures to be gone from #917

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Improved test determinism and type safety for component and hook tests.

* **Chores**
  * Updated TypeScript path resolution configuration across projects for better module aliasing consistency.
  * Refined ESLint rules for Vue files to enforce consistent block ordering practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->