### PR TITLE
docs: product planning methodology + openbadges rebuild planning bundle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,7 @@ packages/claude-knowledge/.claude/
 
 # Git worktrees for /auto-milestone
 .worktrees/
+
+# Local tooling artifacts
+.superset/
+.claude/scheduled_tasks.lock

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,23 @@ Keep solutions simple and focused. Only make changes directly requested.
 - Reuse existing patterns; minimum complexity needed
 - **Fix issues now** - When reviews identify problems, fix immediately. No tech debt.
 
+## Product Planning Methodology
+
+**When the user asks to plan a product, rebuild, feature, or package, follow the documented methodology — do not invent your own sequence.**
+
+Canonical doc: [`apps/docs/processes/product-planning.md`](apps/docs/processes/product-planning.md)
+
+Sequence: **User Stories → Vision Docs → Design Docs → ADRs / Planning → Build.** Each phase feeds the next. Stories come first, always.
+
+Key rules agents get wrong and **must not**:
+
+- Never refuse to write a user story because "the feature / tool / CLI doesn't exist yet." Stories are forward-looking by design — they are how the project decides what to build.
+- Never jump to implementation, vision, or design before stories are solid.
+- Never treat stories as specs. They are narrative, present-tense, actor-driven. Specs come later.
+- Never delete a story; mark it _needs rework_ and move on.
+
+Read `apps/docs/processes/product-planning.md` before engaging in any planning conversation.
+
 ## Workflows
 
 | Command                  | Use Case                         |

--- a/apps/docs/processes/product-planning.md
+++ b/apps/docs/processes/product-planning.md
@@ -1,0 +1,208 @@
+# Product Planning Methodology
+
+**Status:** Accepted
+**Owner:** Joe
+**Last updated:** 2026-04-23
+**Applies to:** All apps and packages in the `rollercoaster.dev` monorepo, including `native-rd`, `openbadges-system`, `openbadges-ui`, and the shared `openbadges-*` packages.
+
+---
+
+## Purpose
+
+This document captures **how product planning happens** in the rollercoaster.dev ecosystem. It exists so that agents and collaborators starting new work — a new product, a rebuild, a major feature, a new package — follow the same sequence the project has already proven works (most recently on `native-rd`).
+
+If you are an agent, **read this before proposing or agreeing to any planning activity**. If the user says "let's plan X," "let's write stories for Y," or "how do I build this," your default is this methodology unless the user explicitly overrides it.
+
+---
+
+## The sequence (in order)
+
+```
+ User Stories  →  Vision Docs  →  Design Docs  →  ADRs / Planning  →  Build
+  (target             (what it        (how it         (how we'll         (implementation,
+   experience)         is, who          looks and        build it)         issues,
+                       for, how         feels)                             milestones)
+                       it relates)
+```
+
+Each phase feeds the next. Skipping a phase is a mistake — the later phases lose grounding and the work drifts.
+
+### 1. User Stories — start here
+
+Write narrative stories describing **the target experience** — what you want the product to deliver once it's built. Stories drive everything downstream. Nothing else gets written until stories are solid.
+
+**Stories are forward-looking by design.** They describe what _should_ be possible, not what already works. Refusing to write a story because "the feature doesn't exist yet" is **the exact opposite of the point**: the story is how you define what needs to be built in the first place.
+
+If a CLI doesn't exist yet, write the story of the developer using the CLI. If the AI-agent integration isn't built, write the story of the agent using the API. Those stories are the thing the vision docs, design docs, ADRs, and build tickets are all serving.
+
+See the "How to write a story" section below for structure.
+
+### 2. Vision Docs
+
+Once stories are solid, write vision documentation:
+
+- **What it is** — product definition
+- **Who it's for** — audience, not personas-in-abstract
+- **What it isn't** — explicit non-goals
+- **How it relates** — to other products, packages, standards
+- **Core principles** — the values that decide edge cases
+- **Iteration strategy** — the A/B/C/D breakdown (see below)
+
+Canonical example: [`apps/native-rd/docs/vision/product-vision.md`](../../native-rd/docs/vision/product-vision.md).
+
+Vision docs are filtered by stories. If a proposed vision claim can't be traced back to a story it serves, cut it.
+
+### 3. Design Docs
+
+Once vision is settled, write design documentation:
+
+- **Design language** — visual identity, typography, color, spacing
+- **Design principles** — ND rules, accessibility, interaction patterns
+- **User flows** — how users move through the product
+- **Component design** — the building blocks
+
+Canonical examples:
+
+- [`apps/native-rd/docs/vision/design-principles.md`](../../native-rd/docs/vision/design-principles.md)
+- [`docs/design/DESIGN_LANGUAGE.md`](../../../docs/design/DESIGN_LANGUAGE.md)
+
+Design docs inherit from the ecosystem-wide design language. Don't re-derive; inherit and extend.
+
+### 4. ADRs / Planning
+
+Once design is settled, write technical decision records and implementation plans:
+
+- **ADRs** (Architecture Decision Records) — every significant technical choice, with context, decision, consequences
+- **Iteration strategy doc** — what ships in A, B, C, D (canonical: [`ADR-0001`](../../native-rd/docs/decisions/ADR-0001-iteration-strategy.md))
+- **Architecture docs** — data model, sync, deployment
+- **Roadmap** — sequencing and dependencies
+
+### 5. Build
+
+Only now do issues get filed and code gets written. Each issue traces back, through ADRs and design docs, to a user story.
+
+---
+
+## Iteration discipline
+
+The rollercoaster.dev approach is **iteration-based product shipping**, not continuous feature creep.
+
+**Rules:**
+
+1. **Each iteration ships as a complete, usable product.** Not a demo, not a prototype. `native-rd`'s Iteration A is a functional self-signed badge tool today, even without Iterations B, C, D.
+2. **Complexity is earned.** Don't design A with B's requirements baked in. Let B inform A's data model, but don't let B inflate A's UI.
+3. **Later iterations build on earlier ones.** Never replace. If Iteration C would require rewriting A's data model, the model was wrong in A and needs fixing before C starts.
+4. **Baby steps, always.** For users (break goals into steps) _and_ for development (A before B before C). Applies recursively within an iteration too.
+
+The canonical breakdown across the rollercoaster.dev ecosystem:
+
+|                                    | Theme                                             |
+| ---------------------------------- | ------------------------------------------------- |
+| **Iteration A — Quiet Victory**    | The core loop. Create, track, earn.               |
+| **Iteration B — Learning Journey** | Manage non-linear life. Stack, interrupts, drift. |
+| **Iteration C — Skill Tree**       | Make invisible progress visible.                  |
+| **Iteration D — Community**        | Peer verification, federation.                    |
+
+New products in the ecosystem should either adopt this framework or explicitly justify why theirs differs.
+
+---
+
+## How to write a user story
+
+The canonical reference is [`apps/native-rd/docs/vision/user-stories.md`](../../native-rd/docs/vision/user-stories.md). Read a few stories there before writing your own.
+
+### Structure
+
+Each story has:
+
+1. **Title** — a short scene that hints at the outcome
+2. **Metadata header** — Actor, Actor class, Iteration, Status, Claim validated (one line stating what this story proves)
+3. **Narrative** — 200–500 words, present tense, named actor, concrete details. Read like a short scene, not a spec.
+4. **Footer** — _Features used_, _Evidence types_, _ND pattern_ or _Why this belongs on web / mobile / CLI_, _Anti-requirements this enforces_
+
+### Voice
+
+Match the voice of the landing page and of existing stories:
+
+- Non-judgmental, empathetic, factual
+- Specific details (names, times, small concrete moments)
+- No hype, no marketing copy, no "seamless experience"
+- Character moments where they belong (quiet empty states, small personality on milestones) — not in buttons, errors, or verification
+
+### Iteration labels
+
+Match the four-iteration framework. If a story crosses iterations, pick the earliest one where it would ship. If a story is explicitly aspirational and doesn't fit any iteration yet, park it in a clearly-labeled "Parked / future" section with a note.
+
+### Status labels
+
+- **Target state** — the scenario the story describes is what we want to build
+- **Partially true today** — parts work; the story describes the intended full state
+- **Needs rework** — the story is in the file but the author isn't satisfied; placeholder for later
+
+### Anti-requirements
+
+Every story should, where possible, **surface at least one anti-requirement** — something the story implicitly rules out. Anti-requirements are captured as they emerge during story writing, not as a separate task. They protect scope.
+
+Example: a story where a user verifies a badge without signing up implies the anti-requirement _"no sign-up wall for verification."_ Capture it.
+
+### Do not
+
+- **Do not gatekeep stories on "the feature doesn't exist yet."** The story is how you _define_ what needs to exist.
+- **Do not write stories as tickets or specs.** Stories are narrative. Specs come later.
+- **Do not write stories only for current users.** Include the aspirational user whose product this will serve once built.
+- **Do not skip the metadata header.** Agents downstream read the header to route the story correctly; prose alone isn't enough for downstream automation.
+- **Do not delete a story you dislike.** Mark it _needs rework_ and move on. Deletion loses the slot and the intent.
+
+---
+
+## Collaboration rhythm
+
+When planning with an agent:
+
+1. **Start with a short read.** Agent reads the canonical native-rd vision docs, ADR-0001, and design-principles before proposing structure.
+2. **Agent drafts, user reacts.** The user's gut is the authoritative signal on whether a story is right. Don't expect the user to specify upfront; draft concrete artifacts and let the user push back.
+3. **One question at a time.** When the agent needs clarification, pick the single most-blocking question and ask it cleanly. Don't dump lists of questions on a tired author.
+4. **No pretend agreement.** If a draft story is wrong, say so — don't polish it. The frustration breaker rule applies: if the user pushes back twice in a row, stop and reset rather than iterating on a bad draft.
+5. **Capture anti-requirements in the stories file as they emerge.** Don't defer to a separate document.
+6. **Keep a change log.** Every story file has a change log at the bottom. Every substantive edit adds an entry.
+
+---
+
+## What "stories are solid" means
+
+You know the stories are solid and ready to feed the vision phase when:
+
+- Every iteration (A, B, C, D) has at least one story
+- Every intended actor class appears in at least one story
+- Each story's "claim validated" is distinct (no two stories validate the same thing)
+- The author has read through the file end-to-end and has no _needs-rework_ entries left
+- Anti-requirements captured from the stories form a coherent list that you'd be willing to publish as rules
+
+Before this point, don't advance to vision docs. The vision will inherit the story file's problems.
+
+---
+
+## Anti-patterns to avoid
+
+- **Jumping to implementation before stories exist.** "Let me just build the thing" is how the first `openbadges-system` and `openbadges-ui` became a mess. The rebuild exists because planning was skipped.
+- **Writing vision docs first.** Vision without stories is abstract and drifts. Stories without vision docs is survivable; vision without stories is not.
+- **Specifying stories.** If a story has field types, API shapes, or interface definitions in it, those belong in design or ADR docs. Move them.
+- **Using "feature X doesn't exist yet" as a reason to not write the story.** This is the most common mistake. The story is the reason the feature will exist. See the Do Not list above.
+- **Letting one agent session redesign the process.** The methodology is stable. If an agent proposes changing the sequence, stop and reference this doc. Changes to the methodology itself are made deliberately, not mid-session.
+
+---
+
+## Canonical references
+
+- **User stories example:** [`apps/native-rd/docs/vision/user-stories.md`](../../native-rd/docs/vision/user-stories.md)
+- **Vision doc example:** [`apps/native-rd/docs/vision/product-vision.md`](../../native-rd/docs/vision/product-vision.md)
+- **Design principles example:** [`apps/native-rd/docs/vision/design-principles.md`](../../native-rd/docs/vision/design-principles.md)
+- **Iteration strategy ADR example:** [`apps/native-rd/docs/decisions/ADR-0001-iteration-strategy.md`](../../native-rd/docs/decisions/ADR-0001-iteration-strategy.md)
+- **Current rebuild planning (openbadges-system):** [`apps/docs/vision/openbadges-toolkit-rebuild.md`](../vision/openbadges-toolkit-rebuild.md)
+- **Current stories (openbadges-system rebuild, in progress):** [`apps/openbadges-system/docs/user-stories.md`](../../openbadges-system/docs/user-stories.md)
+
+---
+
+## Change log
+
+- **2026-04-23** — Document created after an agent session where an agent incorrectly refused to write stories for unbuilt tools (CLI, AI-agent integration) on the grounds that it would be "fiction." The author corrected the agent: writing stories for not-yet-built tools _is the point_ — that's how the project decides what to build. This doc captures the methodology explicitly so future agents don't repeat the mistake.

--- a/apps/docs/research/open-source-badge-server-landscape-2026-04.md
+++ b/apps/docs/research/open-source-badge-server-landscape-2026-04.md
@@ -1,0 +1,153 @@
+# Open-Source Open Badges Landscape
+
+**Date:** 2026-04-23
+**Purpose:** Baseline competitive/ecosystem research gathered before rebuilding `openbadges-system` and `openbadges-ui`. Used to identify real gaps vs. duplication risk and to generate anti-requirements for the rebuild.
+**Method:** Web research (WebSearch + direct GitHub/project homepage verification) conducted by a general-purpose research agent. All "last commit" claims verified against the repos at time of writing.
+
+---
+
+## Executive summary
+
+The open-source Open Badges ecosystem is thinner than it appears. Two projects do most of the real work — `edubadges-server` (a Django fork of the now-withdrawn Badgr codebase) and Salava (the Clojure-based Open Badge Passport community edition). The original reference implementations from Mozilla and Concentric Sky are archived or have vanished from GitHub after corporate acquisitions. OB 3.0 / Verifiable Credentials adoption is happening mostly outside the "badge server" category — in the DCC (MIT) and EUDI Wallet (EU) ecosystems — which means there is almost no mature, maintained, institution-agnostic, individual-first, OB 3.0 self-issuing server in the open-source space today.
+
+---
+
+## Comparison table
+
+| Project                                 | License                 | OB 2.0                | OB 3.0 / VC                           | Primary audience                  | Architecture                          | Last meaningful activity                                   | Status                                     |
+| --------------------------------------- | ----------------------- | --------------------- | ------------------------------------- | --------------------------------- | ------------------------------------- | ---------------------------------------------------------- | ------------------------------------------ |
+| Badgr Server (Concentric Sky canonical) | AGPL-3.0 (historically) | Yes                   | Partial                               | LMS / institutions                | Django monolith + API                 | Repo removed from GitHub post-2022 Instructure acquisition | Effectively dead upstream                  |
+| edubadges-server (SURF)                 | AGPL-3.0                | Yes                   | Yes (OB 3.0 / VC)                     | Dutch HE consortium               | Django, Badgr fork                    | 2026-04-21                                                 | Actively maintained                        |
+| Salava / Open Badge Passport CE         | Apache-2.0              | Yes                   | No                                    | Individuals / backpack            | Clojure monolith (Java 8 + MariaDB)   | 2020-10                                                    | Stale; cloud product moved on              |
+| Open Badge Factory                      | Proprietary SaaS        | Yes                   | Yes (since Sept 2025)                 | Enterprise / education            | Cloud-only                            | N/A                                                        | Commercial; only Salava is OSS             |
+| Moodle (core Badges)                    | GPL-3.0                 | Yes                   | Planned                               | LMS users                         | Moodle subsystem                      | Rolling (core)                                             | OB 3.0 schema work "near future"           |
+| Open edX Credentials (Badges)           | AGPL-3.0                | Via Credly/Accredible | No native                             | Course operators                  | Django service                        | Rolling                                                    | Depends on third-party issuers             |
+| Blockcerts (Hyland / MIT)               | MIT                     | Adjacent              | Partial (VC-based, not OB 3.0 native) | Universities, governments         | Python issuer + JS verifier + wallets | cert-issuer 2026-04; cert-verifier 2020                    | Core issuer active; peripheral tools stale |
+| DCC Issuer Coordinator                  | MIT                     | No                    | Yes (VC-API, OBv3 context)            | Higher-ed consortium              | Node microservices                    | 2024-11 (coordinator)                                      | Maintained, modular                        |
+| EUDI Wallet ecosystem                   | Apache / EUPL           | No                    | Yes (OpenID4VCI, mdoc / SD-JWT)       | EU member states                  | Reference wallets + issuers           | 2026-04 (daily)                                            | Very active, badges tangential             |
+| Mozilla Backpack / BadgeKit             | MPL / NOASSERTION       | Yes (historic)        | No                                    | —                                 | Node monolith                         | Archived 2019 / 2020                                       | Dead                                       |
+| Certo (Schroedinger-Hat)                | AGPL-3.0                | No                    | Yes (OB 3.0)                          | Conference / workshop organisers  | Small web app                         | 2026-01                                                    | Tiny but alive                             |
+| Tahrir (Fedora)                         | NOASSERTION (GPL-like)  | Yes                   | No                                    | Fedora contributors / communities | Flask app                             | 2026-04                                                    | Maintained for internal use                |
+| MediaWiki OpenBadges extension          | GPL                     | Yes                   | No                                    | Wiki communities                  | MediaWiki extension                   | 2026-04                                                    | Maintained but niche                       |
+
+---
+
+## Project notes
+
+### Badgr Server
+
+Historically the reference AGPL-3.0 Django implementation from Concentric Sky. Post-Instructure acquisition (April 2022) and the October 2025 rebrand to "Parchment Digital Badges", the canonical `github.com/concentricsky/badgr-server` repository returns 404. Free issuer plan sunset **December 31, 2025**. What's left are institutional forks (`edubadges`, `fedora-infra`, `reedu-reengineering`, `EOSC-synergy`, `ctrlwebinc/bf2-badgr-server`) that have diverged.
+
+- **Good at:** a proven issuer / backpack / verification flow institutions already know.
+- **Bad at:** upstream is gone, the codebase is Django circa 2016, OB 3.0 support is inconsistent across forks.
+
+### edubadges-server
+
+https://github.com/edubadges/edubadges-server — AGPL-3.0, ~44 stars, last push **2026-04-21**. The most actively maintained Badgr descendant, built for the Dutch SURF higher-education network. Explicitly supersedes the older `edubadges/badgr-server` fork, which they mark DEPRECATED.
+
+- **Good at:** real OB 3.0 + W3C VC support from a credible institutional consortium.
+- **Bad at:** opinionated for the SURF federation context (eduID, institution hierarchies); not drop-in for a solo issuer.
+
+### Salava / Open Badge Passport CE
+
+https://github.com/openbadgefactory/salava — Apache-2.0, ~21 stars, last push **2020-10-02**. The community edition of Discendum's Open Badge Passport.
+
+- **Good at:** being one of the only OSS projects that treats the earner, not the issuer, as the primary user.
+- **Bad at:** effectively abandoned upstream — Clojure + Java 8 + MariaDB, no OB 3.0, while the hosted OBF product quietly kept going.
+
+### Open Badge Factory
+
+https://openbadgefactory.com — Discendum's commercial SaaS; Salava is the only OSS component and is stale. OBF itself moved to OB 3.0 in September 2025 and is 1EdTech certified. "Open source" framing is misleading in practice: you can't self-host a current OBF.
+
+### Mozilla Open Badges Backpack / BadgeKit
+
+Both archived (2019 and 2020). Historically important; do not use. 867 stars on the Backpack repo, but it's a tombstone.
+
+### Moodle core Badges
+
+GPL, OB 2.0/2.1 today. Forum discussions from 2025 confirm OB 3.0 support is planned but not shipped in core. If you're inside Moodle, badges "just work"; outside, it's not a server.
+
+### Open edX Credentials
+
+Does not issue OB natively; it's a thin wrapper around third-party issuers (Credly, Accredible).
+
+- **Good at:** delivering badges tied to edX courses.
+- **Bad at:** you're renting someone else's issuance.
+
+### Blockcerts / Hyland
+
+MIT-licensed. `blockchain-certificates/cert-issuer` is active (426 stars, 2026-04 push), `cert-verifier-js` is active (114 stars, daily), but the web verifier, viewer, and some wallet pieces haven't moved since 2020–2021.
+
+- **Good at:** blockchain-anchored credentials with MIT-backed provenance.
+- **Bad at:** it's a Blockcerts-shaped hole, not OB 3.0 native; UX assumes you own a wallet.
+
+### DCC (Digital Credentials Consortium)
+
+https://github.com/digitalcredentials — MIT. Not a monolith but a set of composable MIT/Harvard-backed microservices: `issuer-coordinator`, `signing-service`, `verifier-core`, `verifier-plus`, `status-service-db`, and notably `open-badges-context` (the OBv3 JSON-LD context package, 2025-05). This is the closest thing to a credible OB 3.0 reference stack outside Europe.
+
+- **Good at:** modern VC-API, revocation via bitstring status list, academic pedigree.
+- **Bad at:** higher-ed-consortium assumptions, no unified UX, you have to assemble the pieces.
+
+### EUDI Wallet
+
+https://github.com/eu-digital-identity-wallet — 60+ repos, Apache / EUPL, all pushed in the last week. Not a badge platform per se, but OpenID4VCI + SD-JWT + mdoc is what EU-issued credentials (including education attestations) will actually ride on by end of 2026 per eIDAS 2.0.
+
+- **Good at:** being the regulatory forcing function for the next five years.
+- **Bad at:** nothing here targets badges specifically; diploma / micro-credential use cases are "on the roadmap" rather than shipped.
+
+### Certo
+
+https://github.com/Schroedinger-Hat/certo — AGPL-3.0, ~19 stars, last push **2026-01-28**. An Italian open-source project aimed at workshop / conference organisers issuing OB 3.0 certificates. Small but alive and genuinely OB 3.0 focused — worth watching.
+
+### Tahrir (Fedora)
+
+https://github.com/fedora-infra/tahrir — Flask-based "issue your own Open Badges" app, ~84 stars, active. Built by and for the Fedora community (FAS accounts assumed).
+
+- **Good at:** simple, self-hostable, tested at real community scale.
+- **Bad at:** OB 2.0 only, opinionated about the Fedora identity stack.
+
+### MediaWiki OpenBadges extension
+
+Maintained but purely a MediaWiki add-on; not a general-purpose server.
+
+---
+
+## Five gaps / opportunities
+
+1. **There is no actively maintained, OB 3.0-native, individual-first open-source badge server.** Salava was the closest philosophically and it's been stale since 2020. Every actively maintained option (edubadges, Open edX, Moodle, OBF) assumes an institution is the primary actor. An earner-first self-signing server is a genuinely empty slot — not a duplicate.
+
+2. **"Badgr" as a brand is effectively dead upstream**, but thousands of existing badges in the wild point at Badgr URLs. There's a real need for a drop-in verifier / migration path as Parchment sunsets the free tier on 2025-12-31 — that's a concrete, time-boxed opportunity rather than a vague "build a better Badgr."
+
+3. **OB 3.0 is shipping on paper but almost nowhere in self-hostable OSS.** OBF flipped in Sept 2025 (proprietary), edubadges-server has it (institutional), DCC has the pieces (assembly required), Certo is tiny. A polished, single-binary, OB 3.0-first server with VC-API + bitstring status list would not be duplicating any maintained project.
+
+4. **Federation / cross-server verification is not solved.** Every deployment is an island. The DCC VerifierPlus and 1EdTech's public validator verify individual credentials, but there is no "badge fediverse" — no ActivityPub experiments with OB 3.0 surfaced in the search, despite the obvious conceptual fit (earner-owned inbox of achievements). This is greenfield.
+
+5. **The EUDI Wallet is going to eat education credentials by 2027** whether the badge-server world is ready or not. OpenID4VCI + SD-JWT is where regulated issuance will land. A server that speaks _both_ OB 3.0 (the 1EdTech world) _and_ OpenID4VCI (the EU wallet world) as first-class outputs would bridge a gap nobody in either camp has closed — edubadges-server does OB 3.0, EUDI does OpenID4VCI, but no one in the OSS badge space does both credibly today.
+
+---
+
+## Observation: every actively-maintained option is monolithic
+
+Across the whole list, the delivery shape is the same: **one Django/Clojure/Flask app, one database, one deploy unit.** The only exception is the DCC, which is a constellation of microservices — and even DCC is scoped to institutional issuance, not toolkit reuse. No project in this landscape positions itself as **a toolkit for other developers to build badge features into their own products**. This is probably the most significant structural gap: not a missing feature, but a missing posture.
+
+---
+
+## Sources
+
+- Instructure acquisition of Concentric Sky: https://www.instructure.com/press-release/instructure-acquires-concentric-sky
+- Canvas Credentials → Parchment Digital Badges rebrand / free tier sunset: https://community.canvaslms.com/ (summarised via search)
+- edubadges-server: https://github.com/edubadges/edubadges-server
+- Salava: https://github.com/openbadgefactory/salava
+- Open Badge Factory OB 3.0 migration: https://openbadgefactory.com/en/your-badges-are-now-open-badges-3-0/
+- 1EdTech OB 3.0 spec: https://www.imsglobal.org/spec/ob/v3p0 and https://github.com/1EdTech/openbadges-specification
+- Blockcerts org: https://github.com/blockchain-certificates (notably `cert-issuer`, `cert-verifier-js`)
+- Digital Credentials Consortium: https://github.com/digitalcredentials (notably `issuer-coordinator`, `open-badges-context`, `verifier-plus`)
+- EUDI Wallet: https://github.com/eu-digital-identity-wallet and https://eu-digital-identity-wallet.github.io/eudi-doc-architecture-and-reference-framework/2.5.0/
+- Moodle OB 3.0 status: https://moodle.org/mod/forum/discuss.php?d=438152 and https://moodledev.io/docs/5.2/apis/subsystems/badges
+- Open edX Credentials / Badges: https://docs.openedx.org/projects/edx-credentials/en/latest/badges/
+- Mozilla Backpack (archived): https://github.com/mozilla/openbadges-backpack
+- BadgeKit (archived): https://github.com/mozilla/openbadges-badgekit
+- Certo: https://github.com/Schroedinger-Hat/certo
+- Tahrir: https://github.com/fedora-infra/tahrir
+- MediaWiki OpenBadges extension: https://github.com/wikimedia/mediawiki-extensions-OpenBadges
+- Hyland / Blockcerts background: https://www.hyland.com/en/solutions/products/hyland-credentials and https://www.blockcerts.org/about.html

--- a/apps/docs/research/selective-disclosure-feasibility-2026-04.md
+++ b/apps/docs/research/selective-disclosure-feasibility-2026-04.md
@@ -1,0 +1,145 @@
+# Feasibility Research — Per-Recipient Selective Disclosure on Self-Signed OB 3.0
+
+**Date:** 2026-04-23
+**Purpose:** Validate whether Story 2 (Lina chooses exactly what her librarian sees) in [`apps/openbadges-system/docs/user-stories.md`](../../openbadges-system/docs/user-stories.md) can be built. Decide the cryptographic approach, the library stack, and the honest fall-back before user-story work continues.
+**Method:** Web research (specs, IETF drafts, W3C CRs, library repos, production implementations) via a general-purpose research agent, verified against actual repo state.
+
+---
+
+## One-paragraph verdict
+
+**Feasible with significant compromise, leaning toward aspirational-only for the full story as initially described.** As of April 2026, the pieces exist on paper — OB 3.0 rides on W3C VC Data Model 2.0, RFC 9901 (SD-JWT) was finalized November 2025, and selective-disclosure cryptosuites (`ecdsa-sd-2023`, `bbs-2023`) are published with reference JS implementations. But three load-bearing problems make the _full_ cryptographic SD vision a poor solo-dev target today: (1) **1EdTech's OB 3.0 conformance targets only `eddsa-rdfc-2022` and `RSA256` JWT** — SD cryptosuites are not part of OB 3.0 conformance, so you'd be shipping something certified verifiers can't validate; (2) **binary blobs (photos, screenshots) are not well-served by message-based SD** — you get hash-referenced evidence with external hosting, which breaks pure local-first; (3) **no existing project ships this exact pattern**. A solo builder can ship a credible 80% version using a **per-recipient wrapped-presentation approach** (detailed below) that delivers the entire user-facing experience Lina's story promises, with mature libraries and without faking cryptography.
+
+---
+
+## Feasibility grade per sub-question
+
+| #   | Topic                                      | Grade                                                                  | Short reason                                                                                                                                                                                                                                                              |
+| --- | ------------------------------------------ | ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | OB 3.0 + SD cryptosuites                   | **YELLOW → RED**                                                       | OB 3.0 permits VCDM 2.0 proofs generically, but 1EdTech conformance targets EdDSA/RSA-JWT only. No 1EdTech SD test vectors.                                                                                                                                               |
+| 2   | SD-JWT viability in TS/JS                  | **GREEN**                                                              | RFC 9901 is final (Nov 2025). `@sd-jwt/*` (OpenWallet Foundation) at v0.19.0, Jan 2026, ~3.1k weekly downloads. Hidden = absent (salted digests), not redacted placeholders.                                                                                              |
+| 3   | BBS / ECDSA-SD in TS/JS                    | **YELLOW**                                                             | `@digitalbazaar/bbs-2023-cryptosuite` and `ecdsa-sd-2023-cryptosuite` exist and are interop-tested (W3C report Apr 2026), but repos have <20 stars, niche adoption. MATTR's `bbs-signatures` archived Feb 2025. Pairing-crypto is the live path.                          |
+| 4   | Evidence array SD + binary blobs           | **YELLOW**                                                             | SD-JWT and BBS both support per-array-element disclosure. But inlined photos as data URIs blow up SD payload sizes; hash-referenced is standard, which means **you must host the hidden-from-X blobs somewhere X can't reach** — pure local-first breaks.                 |
+| 5   | Local-first key management on web          | **YELLOW**                                                             | WebAuthn PRF has broad 2026 support (Chrome, Firefox 148+, iOS 18.4+, Windows 11 25H2), but PRF produces a symmetric secret, not an Ed25519/BLS signing key. You use PRF to unlock an IndexedDB-stored signing key. Direct passkey-signs-credential is still not a thing. |
+| 6   | Delivery + revocation                      | **GREEN** for per-share-URL + delete; **YELLOW** for crypto revocation | Bitstring Status List is the standard but gives per-credential status, not per-share. Per-share is usually "distinct derived presentation at distinct URL, delete to revoke."                                                                                             |
+| 7   | Practical precedent for this exact pattern | **RED**                                                                | DCC LCW (now OpenWallet-Foundation-stewarded since Jan 2025) supports OB 3.0 but not per-recipient evidence SD. No shipped tool does "one OB 3.0 credential → N per-recipient evidence-filtered disclosures."                                                             |
+
+---
+
+## Recommended cryptographic approach
+
+**Wrapped-presentation per recipient, using SD-JWT VC if and when SD lands on the OB 3.0 conformance runway — not before.**
+
+For Iteration A:
+
+- **One self-signed OB 3.0 credential** in compact JWS form (`eddsa-rdfc-2022` or JWT RS256) — certifiable, verifiable by any OB 3.0 verifier.
+- **Evidence items stored local-first by content hash.** The credential references content hashes, not embedded blobs. Blobs live in local storage + an access-controlled blob relay.
+- **Per-recipient "share package"** = a freshly-signed presentation wrapping: the original credential + the subset of evidence blobs Lina chose + a per-recipient framing note. Signed by Lina's share-time key at share construction.
+- **Per-share capability URL** with a random token. Revocation = delete the share package + flip a bit in a status list Lina hosts.
+- **Hidden evidence is genuinely not present** in the share package — because the package is freshly constructed per recipient, not a derivation from a single SD signature. Recipients cannot enumerate what else exists; they see only what Lina wrapped.
+- **WebAuthn + PRF** to unlock an IndexedDB-stored Ed25519 key for signing share packages.
+
+Why this over the alternatives:
+
+- **vs. BBS (`bbs-2023`)**: BBS gives unlinkability, which sounds great but isn't free — BLS12-381 (WASM), tiny JS ecosystem (<20 stars across repos), not on OB 3.0's conformance runway. For Lina's use case the threat model is weak: librarian and hiring manager aren't colluding. Big complexity tax for a property the story doesn't need.
+- **vs. `ecdsa-sd-2023`**: Fewer moving parts than BBS but still JSON-LD / canonicalization. Reference implementation has 16 stars. Very early production territory.
+- **vs. SD-JWT VC as primary**: SD-JWT is the most mature crypto-SD path in 2026, but it's also not on 1EdTech's OB 3.0 conformance runway. Wrapped presentation delivers the same user experience with simpler, more portable primitives today, and the SD-JWT path remains available as a future upgrade.
+
+**Trade-offs you accept:**
+
+- No cryptographic unlinkability across shares (librarian and hiring manager could in principle compare notes and see it's the same underlying credential — but they can already, via the issuer DID).
+- Not a 1EdTech-blessed "selective disclosure proof." But 1EdTech doesn't certify SD anyway — so no tooling penalty.
+
+**Trade-offs you avoid:**
+
+- JSON-LD canonicalization complexity.
+- Bleeding-edge crypto with <20-star library backing.
+- Waiting for 1EdTech to bless SD cryptosuites (indeterminate).
+
+---
+
+## Library shortlist
+
+| Package                                                       | Status as of 2026                                              | Use for                                            |
+| ------------------------------------------------------------- | -------------------------------------------------------------- | -------------------------------------------------- |
+| `@sd-jwt/core`, `@sd-jwt/sd-jwt-vc`, `@sd-jwt/crypto-browser` | v0.19.0 (Jan 2026), ~3.1k weekly dl, OpenWallet Foundation     | Future SD upgrade; not needed for v1               |
+| `@digitalbazaar/vc`                                           | Actively maintained                                            | Native Data Integrity path for 1EdTech conformance |
+| `@simplewebauthn/browser` + PRF extension                     | Browser-side passkey + PRF to unlock IDB-encrypted Ed25519 key | Web key management                                 |
+| `@noble/ed25519`, `@noble/curves`                             | Audited, zero-dep                                              | Signing in the browser                             |
+| `@digitalbazaar/bbs-2023-cryptosuite`                         | 60 commits, 6 tags, beta-ish                                   | Only if unlinkability becomes a real requirement   |
+| `@digitalbazaar/ecdsa-sd-2023-cryptosuite`                    | 252 commits, 16 stars, interop tests Apr 2026                  | Backup path; niche                                 |
+| **Avoid:** `@mattrglobal/bbs-signatures`                      | **Archived Feb 2025**                                          | Do not adopt. Use `pairing_crypto` if you go BBS.  |
+| **Avoid:** `@meeco/sd-jwt-vc`                                 | Less active than OWF's                                         | Prefer OWF's `sd-jwt-js` family                    |
+
+---
+
+## Known pitfalls
+
+1. **Evidence blobs force a hosting decision.** You cannot inline 2MB photos as data URIs across many disclosures. Standard pattern: store blobs by content hash, reference from evidence items, serve over per-recipient capability URLs. Hidden-from-librarian blobs still need to live somewhere the librarian can't GET — you'll need an access-controlled blob store. Pure local-first is compromised: blobs serve from user's device when online, or from a relay/pinning service when not.
+2. **"Hidden is invisible" breaks at the filename layer.** If evidence items have descriptive `name` fields ("Sobriety-journal-Jan.jpg") you leak metadata in the digests unless each entire evidence object is one disclosure blob. Design the evidence schema so each item is atomic.
+3. **WebAuthn PRF is not signing.** PRF returns a 32-byte symmetric secret tied to a passkey. Use it to wrap an Ed25519 signing key at rest in IndexedDB. The passkey does not directly sign credential payloads. Users on non-PRF-capable authenticators need a fallback.
+4. **Generic OB 3.0 verifiers will not ingest SD-JWT or wrapped-presentation formats directly.** A librarian using a third-party verifier will fail. You must ship your own verifier UI for share packages, plus produce a fully-disclosed plain OB 3.0 credential on demand for dumb-verifier cases.
+5. **Revocation ≠ deletion.** Deleting a share URL works until the recipient has cached the disclosure offline. For genuine revocation use per-share status list entries (Bitstring Status List, one bit per share, not per credential). The issuer's device must periodically serve the status list.
+6. **Self-signed + selective disclosure has a trust-model note.** A hiring manager can verify the signature, but "Lina signed a credential saying Lina did X" is circular. Stories and UX should be explicit: the evidence is what's being evaluated; the signature proves _it was Lina who published this specific disclosure_, nothing more. Peer / mentor endorsement (Iteration D) is what adds external trust.
+7. **`ecdsa-sd-2023` and `bbs-2023` are JSON-LD based.** Canonicalization (`jsonld.js`, RDF canonicalization) has its own historical footguns. SD-JWT avoids this entire category — another reason it's the default future-upgrade path.
+
+---
+
+## The 80% version that Story 2 actually describes
+
+Reading Lina's story carefully, the _user experience_ it promises is fully deliverable today with the wrapped-presentation approach. What changes is the underlying mechanism, not the user-visible behavior:
+
+| Story promise                                                   | Deliverable today  | How                                                                                            |
+| --------------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------- |
+| Data + keys stay on Lina's devices                              | YES                | IndexedDB + WebAuthn PRF + Ed25519 via `@noble/ed25519`                                        |
+| Per-recipient evidence toggles                                  | YES                | Share-time UI; wrapped-presentation constructed from chosen subset                             |
+| Hidden pieces genuinely not-present (not redacted placeholders) | YES                | Share package contains only chosen items; recipient can't enumerate what's missing             |
+| Recipient-specific framing notes                                | YES                | Added to the wrapped presentation as new signed statements at share time                       |
+| Revocation per share                                            | YES (with caveats) | Delete share + per-share status list bit                                                       |
+| Same badge → many disclosures to many audiences                 | YES                | One credential, many wrapped presentations; no data duplication beyond the small JSON wrappers |
+| Verifiable without central server                               | YES                | Verifier checks Lina's signature over the share package + the underlying credential signature  |
+| Fully public mode when Lina chooses                             | YES                | Public share = wrapped presentation with all evidence + a public URL                           |
+
+**The thing the story implicitly promised but can't be delivered cleanly:** cryptographic unlinkability between shares. If the librarian and the hiring manager compare notes, they can tell both shares come from the same underlying credential (same issuer DID, same credential ID). This is a weak threat for Lina's use case — she's deliberately sharing with both — but the story should not imply otherwise. Unlinkability is achievable later by upgrading to BBS, if it ever matters.
+
+---
+
+## Upgrade path
+
+When 1EdTech publishes SD guidance (watch `vc-jose-cose` uptake in the OB conformance suite) and the SD-JWT tooling matures further:
+
+1. Swap the wrapped-presentation layer for SD-JWT VC.
+2. Keep the evidence-hashing, blob-relay, and key-management layers as-is.
+3. If genuine unlinkability becomes a user need (it probably won't for individual earners; might for clinical or high-stakes credentials), add BBS as a parallel signature format.
+
+The architecture choice in v1 does not lock out any of these upgrades.
+
+---
+
+## What Story 2's anti-requirements should be updated to say
+
+Current anti-requirements in Story 2 are directionally correct but miss architectural constraints this research surfaced. Recommended additions:
+
+- Evidence blobs are stored by content hash; the credential references hashes, not embedded blobs.
+- Each share is a freshly-signed presentation wrapping the credential + chosen evidence + optional recipient-specific note. Shares are not derivations of a single SD signature.
+- Web key management uses WebAuthn + PRF (or equivalent) to unlock an IndexedDB-stored Ed25519 signing key. Users on non-PRF authenticators get a deliberately-chosen fallback (passphrase-derived key or similar) — not silent failure.
+- Per-share revocation is cryptographic (status list bit), not just file deletion.
+- Self-signed credentials carry the honest trust-model footnote: Lina's signature proves _authorship of the disclosure_, not external validation of the claim. External validation is Iteration D (peer / mentor).
+
+---
+
+## Sources
+
+- [Open Badges 3.0 Spec](https://www.imsglobal.org/spec/ob/v3p0) and [Implementation Guide](https://www.imsglobal.org/spec/ob/v3p0/impl)
+- [RFC 9901 — Selective Disclosure for JSON Web Tokens](https://datatracker.ietf.org/doc/rfc9901/)
+- [draft-ietf-oauth-sd-jwt-vc-15](https://datatracker.ietf.org/doc/draft-ietf-oauth-sd-jwt-vc/)
+- [W3C Data Integrity BBS Cryptosuites v1.0](https://www.w3.org/TR/vc-di-bbs/)
+- [W3C Data Integrity ECDSA Cryptosuites v1.0](https://www.w3.org/TR/vc-di-ecdsa/)
+- [W3C VC-JOSE-COSE](https://www.w3.org/TR/vc-jose-cose/)
+- [digitalbazaar/ecdsa-sd-2023-cryptosuite](https://github.com/digitalbazaar/ecdsa-sd-2023-cryptosuite) · [bbs-2023-cryptosuite](https://github.com/digitalbazaar/bbs-2023-cryptosuite)
+- [openwallet-foundation/sd-jwt-js](https://github.com/openwallet-foundation/sd-jwt-js) (v0.19.0, Jan 2026)
+- [mattrglobal/bbs-signatures — archived Feb 2025](https://github.com/mattrglobal/bbs-signatures) → successor [pairing_crypto](https://github.com/mattrglobal/pairing_crypto)
+- [WebAuthn PRF Developer Guide (Yubico)](https://developers.yubico.com/WebAuthn/Concepts/PRF_Extension/Developers_Guide_to_PRF.html) and [Corbado 2026 PRF status](https://www.corbado.com/blog/passkeys-prf-webauthn)
+- [W3C Bitstring Status List](https://www.w3.org/TR/vc-bitstring-status-list/)
+- [DCC stewardship transfer to OWF, Jan 2025](https://medium.com/open-learning/dcc-transfers-stewardship-of-learner-credential-wallet-to-the-open-wallet-foundation-24fe0c336829)
+- [W3C ECDSA Interop Report (Apr 2026)](https://w3c.github.io/vc-di-ecdsa-test-suite/)

--- a/apps/docs/vision/openbadges-toolkit-rebuild.md
+++ b/apps/docs/vision/openbadges-toolkit-rebuild.md
@@ -1,0 +1,147 @@
+# OpenBadges Toolkit Rebuild — Planning Scope
+
+**Status:** Working draft — actively being developed
+**Date started:** 2026-04-23
+**Owner:** Joe
+**Phase:** User stories (step 1 of: stories → vision → design → planning)
+
+> This is a **living capture doc** for the rebuild of the openbadges toolkit and its reference implementation. It holds decisions, personas, inventory, and parked ideas in one place while user stories are being developed. Not a finished artifact — expect churn. When planning concludes, settled parts get promoted into `vision/`, `product/`, `architecture/`, and ADRs; this doc gets archived.
+
+---
+
+## The thesis (one line)
+
+**An OB 3.0-native, earner-first, composable open-source toolkit for building credentialing into anything — with a reference implementation that makerspaces and small orgs can actually run.**
+
+---
+
+## Why a rebuild
+
+The current `openbadges-system` and `openbadges-ui` were exploratory first attempts — built to prove the work was possible, without a vision or scope discipline. `native-rd` taught the lessons that will guide this rebuild: tight scope, iteration-based story planning, design-first thinking, neurodivergent-first UX.
+
+The landscape research (see `apps/docs/research/open-source-badge-server-landscape-2026-04.md`) confirms the rebuild is not duplicating existing work. Every actively-maintained OSS badge project is a monolith aimed at institutional issuance. An earner-first, toolkit-shaped, OB 3.0-native project is a genuine gap.
+
+---
+
+## What makes this different — posture, not features
+
+Every actively-maintained OSS badge project is **monolithic**: one app, one database, one deploy unit. This one is a **toolkit** — small, composable libraries + a reference showcase — not a single-deploy app.
+
+The moat isn't features. It's posture:
+
+- **Composable over complete.** Small libraries that do one thing, not one app that does everything.
+- **Earner-first over institution-first.** The person who did the thing is the primary user; issuers extend that, they don't own it.
+- **OB 3.0-native over OB 2.0-compatible.** Bet on where the spec is going; don't anchor to 2012.
+- **Reference implementation as fiduciary duty.** The showcase app only uses public toolkit APIs. If it can't, the toolkit is lying.
+
+Model: Tailwind + Tailwind UI + shadcn/ui. Not: Moodle or Badgr.
+
+---
+
+## Toolkit inventory
+
+### Existing packages (published today)
+
+| Package            | Status              | Role after rebuild                                                                                                    |
+| ------------------ | ------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `openbadges-types` | Active              | Keep. Foundation — TypeScript types for OB 2.0/3.0.                                                                   |
+| `openbadges-core`  | Active              | Keep. Signing, verification, PNG baking. Already used by `native-rd`.                                                 |
+| `openbadges-ui`    | Exploratory / messy | **Rebuild.** Vue 3 components — slim down, drop institutional assumptions, add neo-brutalist design system alignment. |
+| `rd-logger`        | Active              | Keep. Structured logging used across monorepo.                                                                        |
+
+### Existing reference implementations
+
+| App                         | Status              | Role after rebuild                                                                                                |
+| --------------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `openbadges-system`         | Exploratory / messy | **Rebuild.** Vue + Hono reference web app. Becomes the showcase of what's possible with the toolkit.              |
+| `openbadges-modular-server` | Exists              | Decision pending — keep as separate API server? merge into `-core`? re-scope?                                     |
+| `native-rd`                 | Active              | Keep. Mobile app, earner-facing. Already consumes `openbadges-core`. Remains the mobile reference implementation. |
+
+### Planned additions
+
+| Package            | Role                                                                                                                                | Source                                                 |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| **Badge Designer** | Visual badge image creator. Integrated into `openbadges-system`. Possibly also a standalone package/app.                            | Extract from `native-rd`'s existing badge designer TS. |
+| **CLI**            | Terminal tool for developers to issue, verify, and track credentials. Dual purpose: usable by humans _and_ by AI agents in scripts. | New.                                                   |
+
+---
+
+## Personas — all critical, tackled one at a time
+
+Joe sees all four consumer personas as critical to the toolkit's success. They will be worked **one at a time** during story drafting, not in parallel — each persona gets its own batch of narrative stories before moving on.
+
+### Toolkit consumers (primary — the thesis lives here)
+
+1. **Solo indie developer** — adds badges to their SaaS via `npm install`. Wants clean TS, small bundle, sensible defaults, no OB3 expertise required.
+2. **Makerspace tech-lead volunteer** — semi-technical, wants runnable services and config files, not library code. Wires the reference server into their existing member-management.
+3. **LMS / institutional platform team** — needs stable public API contracts, OB 3.0 compliance, audit trails, docs that survive a compliance review.
+4. **AI agent / scripting author** — uses the CLI and `openbadges-core` programmatically. Wants deterministic outputs, clean TS imports, minimal runtime assumptions.
+
+### Reference implementation users (proves the toolkit is real)
+
+5. **Makerspace coordinator** — adopts `openbadges-system` whole as their org's platform. Not a developer.
+6. **Instructor / workshop lead** — issues badges to a cohort through the reference app. Cares about low-friction issuance.
+7. **Earner** — receives badges, owns them, carries them into `native-rd`. This is where the ecosystem closes the loop.
+
+---
+
+## Integration modes (sanity check — all three in scope)
+
+- **Mode 1 — Full deployment.** Org runs `openbadges-system` whole. Personas 5, 6, 7.
+- **Mode 2 — Component embed.** Existing app drops in `openbadges-ui` / `openbadges-core`. Personas 1, 3.
+- **Mode 3 — Headless.** CLI + `openbadges-core` + optional `openbadges-modular-server`. Personas 1, 4.
+
+---
+
+## Anti-requirements (captured as we go)
+
+_(To be filled during story work. Seed list from research + conversation so far:)_
+
+- [ ] No story shall require the user to create an "issuer" before they can create a badge. (Lesson: every existing OSS project does this, and it's the first drop-off point for non-institutional users.)
+- [ ] No toolkit package ships without a runnable minimal example (10–20 lines) and a reference use in `openbadges-system`. If we can't write both, the API isn't done.
+- [ ] The reference implementation (`openbadges-system`) shall only use public toolkit APIs. No private side-doors.
+- [ ] No core dependency on a single corporate steward. (Lesson: Badgr died when Instructure acquired it.)
+- [ ] No hard assumptions about a specific identity federation. (Lesson: `edubadges-server` is coupled to SURF's eduID and can't be adopted elsewhere without surgery.)
+- [ ] No stack choices whose maintainers age out. (Lesson: Salava died on Clojure + Java 8 + MariaDB.)
+- [ ] No forced social interaction or account creation for core self-signing flow.
+- [ ] _(more to be added as stories surface them)_
+
+---
+
+## Story pipeline
+
+_(Tracked here as we write. Each entry: persona, story title, status, one-line claim the story validates.)_
+
+| #   | Persona        | Story title | Status | Claim |
+| --- | -------------- | ----------- | ------ | ----- |
+| —   | _(start here)_ | —           | —      | —     |
+
+---
+
+## Parked ideas / open questions
+
+Explicitly _not_ cutting, but _not_ in the first-cut scope. Captured so they don't get lost.
+
+- **Federation / ActivityPub badge inbox** — conceptually compelling, nobody in the space has done it, but it's a scope trap for v1.
+- **EUDI Wallet / OpenID4VCI bridge** — strategically relevant for 2027 per eIDAS 2.0. Defer; consider after v1 lands.
+- **Badge Designer as standalone package** — decision to make after extracting from `native-rd`. Could become its own npm package or stay embedded in `openbadges-system`.
+- **OB 2.0 compatibility** — to what extent? Institutions still live in OB 2.0 (Moodle, Open edX, Canvas). Verification-only? Full issuance? Decide before design phase.
+- **Sustainability / funding model** — not a story question directly, but it shapes pacing. Side project? Grant? Revenue? Needs a separate conversation.
+- **`openbadges-modular-server`'s role after rebuild** — keep as separate API? merge into `-core`? split further? Resolve during architecture phase.
+- **Badge "migration from Badgr" story** — real, time-limited opportunity (Parchment sunsetted free tier 2025-12-31), but the window is mostly closed. Worth one story? Unclear.
+
+---
+
+## Related docs
+
+- **Landscape research:** [`apps/docs/research/open-source-badge-server-landscape-2026-04.md`](../research/open-source-badge-server-landscape-2026-04.md)
+- **Existing ecosystem vision:** [`apps/docs/vision/openbadges-ecosystem.md`](./openbadges-ecosystem.md) — legacy, to be superseded by a new vision doc after stories settle.
+- **Existing user stories (earner-first):** [`apps/docs/product/user-stories.md`](../product/user-stories.md) — keep, extend, cross-link from new stories.
+- **native-rd story model:** [`apps/native-rd/docs/vision/user-stories.md`](../../native-rd/docs/vision/user-stories.md) — tone, structure, iteration-based scoping reference.
+- **Monorepo root:** [`AGENTS.md`](../../../AGENTS.md)
+
+---
+
+## Change log
+
+- **2026-04-23** — Document created. Captured thesis, personas, inventory, integration modes, anti-requirement seeds, parked ideas.

--- a/apps/openbadges-system/docs/user-stories.md
+++ b/apps/openbadges-system/docs/user-stories.md
@@ -1,0 +1,284 @@
+# User Stories — openbadges-system / openbadges-ui Rebuild
+
+**Status:** Draft v0.2 — framework aligned to native-rd vision, individual stories still need re-homing
+**Date:** 2026-04-23
+**Owner:** Joe
+**Phase:** User stories (step 1 of: stories → vision → design → planning)
+
+> These stories drive the rebuild of `openbadges-system` (web reference implementation, deployed as `rollercoaster.dev`) and `openbadges-ui` (Vue component library). They follow the iteration framework already accepted in [ADR-0001 (native-rd)](../../native-rd/docs/decisions/ADR-0001-iteration-strategy.md) so web and mobile evolve in sync.
+
+## Iteration framework (inherits from native-rd ADR-0001)
+
+Each iteration ships as a complete product. No iteration is a throwaway prototype. Complexity is earned.
+
+| Iteration                | Theme                                        | Scope (web-shaped)                                                                                                                                                                                                                      |
+| ------------------------ | -------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **A — Quiet Victory**    | The core loop. Create, track, earn.          | Create goal → break into steps → attach evidence → mark complete → earn self-signed OB3 badge → view + share on web. Local-first, works offline. All 7 ND themes.                                                                       |
+| **B — Learning Journey** | Manage the messy reality of non-linear life. | Multiple concurrent goals, pause/resume, goal journal, learning stack (what interrupted what), factual nudges, drift detection, badge-to-goal linking, multi-device sync. See [Learning Graph](../../../docs/vision/learning-graph.md). |
+| **C — Skill Tree**       | Make invisible progress visible.             | Spatial canvas of badges + goals as nodes, manual placement, user-drawn connections, visual states (earned/in-progress/planned), zoom/pan/filter.                                                                                       |
+| **D — Community**        | The personal tool connects to other people.  | Peer verification, mentor verification, device-to-device sharing, badge import from institutional servers, spec-compliant `eddsa-rdfc-2022` signing upgrade.                                                                            |
+
+## Cross-iteration primary pattern — the Task View
+
+Runs through all iterations. Not a feature, a default interface.
+
+One screen, one next step per active goal. Nothing else. Answers the only question that matters when overwhelmed: _what's the one thing I could do right now?_
+
+On the web this means the landing-dashboard at `rollercoaster.dev` (once you're signed in) is not a progress bar or a goal tree — it's a short list of one-line next steps, tap/click to mark done, nothing else in your face. Depth is available by drilling in. The surface stays quiet.
+
+Not yet built anywhere (even on native-rd as of 2026-02-28). This is a rebuild commitment.
+
+## Inherited design principles
+
+From [native-rd design-principles.md](../../native-rd/docs/vision/design-principles.md) — adopted wholesale, extended where web adds constraints. Do not re-derive; treat these as preconditions for every story:
+
+- **Offline-first.** Anything that requires connectivity is an enhancement.
+- **Reduce cognitive load.** One primary action per screen.
+- **Respect user state.** Show facts, not judgments. No guilt, no time pressure, no streak shame.
+- **Works in 30 seconds.** Quick check-in is the common interaction, deep use is possible but never required.
+- **Self-issuance is always supported.** External verification adds value, never required.
+- **ND-first, not ND-friendly.** 7 themes (light / dark / high contrast / large text / dyslexia / low vision / autism-friendly) ship from day one. Spec compliance (OB3, W3C VC) over shortcuts.
+- **Character moments, selectively.** Empty states, first-time milestones, returns after long absence speak with personality ("First one. (noted.)", "No badges yet. What have you been up to?"). Buttons, errors, and verification stay direct and clear.
+
+## Open questions — unresolved before stories can be finalized
+
+These shape multiple stories and need your call before rewriting:
+
+1. **Is `rollercoaster.dev` a personal product, an institutional reference implementation, or both?** The [native-rd product vision](../../native-rd/docs/vision/product-vision.md) frames the monorepo as _institutional_ infrastructure and native-rd as _personal_. The rollercoaster.dev landing page features four personal users (Lina, Eva, Malik, Carmen). This conversation has treated rollercoaster.dev as Joe's personal product first, with institutional adoption as a later and optional extension. The old vision doc may be stale. Decision affects Stories 4 (makerspace), 7 (EdTech), and the scope of Iteration B on the web.
+2. **Does rollercoaster.dev allow badge creation on the web, or is it a "view/share/verify only" surface that relies on native-rd for creation?** Previous draft of Story 1 assumed the latter; author feedback says that's wrong — the web is a full product. Needs explicit confirmation so Iteration A stories can be written correctly.
+3. **How does web identity work?** Passkeys (matches native-rd)? Something simpler for the earner? How does a user on the web prove they're the same earner as on their phone, without a central account server?
+4. **OB3 cryptosuite for web launch** — match native-rd's current `eddsa-raw-json-iteration-a` (and upgrade together in Iteration D), or go spec-compliant `eddsa-rdfc-2022` from day one on the web since it's greenfield?
+5. **openbadges-modular-server's role.** Native-rd's plan is to extract `openbadges-core` _from_ `openbadges-modular-server`. If rollercoaster.dev is local-first and the reference implementation, does the web app even need the modular server, or does it use `openbadges-core` as a library directly, same as native-rd?
+
+---
+
+> The individual stories below are from draft v0.1 and have **not yet been re-homed** into the corrected iteration framework above. Several are currently mis-labeled and at least one (Story 4 — makerspace) may not belong in this file depending on Open Question #1. They remain for reference until the open questions are resolved.
+
+---
+
+## Iteration A — The web surface exists
+
+The first thing rollercoaster.dev has to earn: a place on the web where a badge can be shown, verified, and designed. No goal tracking (that's native-rd). No accounts (not yet). Just the public face that makes native-rd's private work visible.
+
+---
+
+### Story 1 — _Needs rework_
+
+**Status:** Placeholder — author's gut says this isn't right yet. Previous draft mis-scoped the product as a verifier + public pages rather than a full platform. Leaving the slot open until the story it should tell becomes clear. Do not use previous draft as reference.
+
+---
+
+### Story 2 — Lina chooses exactly what her librarian sees
+
+**Actor:** Lina, 24, autistic — part-time library worker
+**Actor class:** Earner (web surface)
+**Integration mode:** 1
+**Iteration:** A
+**Status:** Target state
+**Claim validated:** Badges are local-first and user-owned. When Lina shares, she decides — per recipient — which pieces of evidence and which notes are visible. Sharing is a disclosure, not a handing-over.
+
+Lina earned her "Local History Archivist" badge weeks ago. It lives on her devices — her phone, her laptop — not on someone else's server. The badge, the evidence, the reflections, the signing keys: hers, on her hardware. Rollercoaster.dev the service never had the full thing and never will.
+
+The head librarian asks to see it. Lina opens rollercoaster.dev on her laptop, picks the badge, and taps _Share_. The interface asks one question in plain language: _"What does [librarian] get to see?"_ and lays out every piece of evidence with a toggle beside it. The before-and-after photos — yes. Her short reflection about why this mattered — yes. The Slack screenshot from the librarian's own thank-you message — she hides that one; it feels strange to reflect it back. A private note she wrote for herself about a coworker who noticed — hidden, obviously.
+
+She taps _Create share_ and gets a link pointed at the librarian. The link opens a page that renders only the pieces Lina chose. The cryptographic proof verifies against Lina's public key. The hidden pieces aren't greyed-out or redacted — they simply aren't in the disclosure. From the librarian's side there's no way to tell what else exists. The badge itself is still one badge, signed once, owned by Lina; what the librarian sees is a _view_ of it.
+
+A month later, a job posting comes up. Lina wants to share the same badge with a hiring manager — but this time she wants to include the Slack screenshot (it's an implicit reference) and add a longer reflection written specifically for that audience. She creates a second share, with different toggles. One badge, two disclosures, recipient-specific. Neither audience sees the other's view. Either share can be revoked any time; when she revokes the librarian's, the link returns a dignified _"This share is no longer available"_ — no shame, no 404, just: _not for you anymore._
+
+If she ever wants a single link she can put on a portfolio page for anyone to see, that's a third option: a public disclosure she builds deliberately, knowing the whole internet is the audience. All three views are verifiable. All three come from the same badge. None of them move ownership off her devices.
+
+**Features used:** Local-first data + key storage, per-recipient share packages (wrapped presentations), evidence-level toggles (show / hide per piece), recipient-specific framing notes, revocable shares, optional fully-public share mode
+**Why this belongs on web:** The librarian is on a laptop. The hiring manager is on a laptop. The share surface — toggles, previews of what each audience sees — is a laptop-ergonomic UI with room to think.
+**Anti-requirements this enforces:**
+
+- Data stays on the user's device(s); the service is a relay, not a repository
+- Sharing defaults to private; public is a choice made explicitly, per share
+- No "share" means "access my data" — every share is a scoped package
+- Hidden pieces are not-present in the share package, not redacted-but-visible (a redacted blob tells viewers what they're missing, which is its own disclosure Lina didn't choose to make)
+- Revocation tears down the specific share, not the badge
+- The same badge supports many shares to many audiences, simultaneously, without copying data or losing ownership
+
+**Architectural commitments (from [selective-disclosure feasibility research](../../../docs/research/selective-disclosure-feasibility-2026-04.md)):**
+
+- Evidence blobs are stored by **content hash**, referenced from the credential — never embedded inline. Blobs live in an access-controlled local/relay store.
+- Each share is a **freshly-signed wrapped presentation** containing the credential + Lina's chosen evidence subset + optional recipient-specific note. Shares are not derivations of a single selective-disclosure signature. This is what makes "hidden is genuinely absent" structurally true: the share is constructed from scratch from the chosen subset, so there's nothing for the recipient to enumerate what isn't there.
+- Web key management uses **WebAuthn + PRF** (or equivalent) to unlock a locally-stored Ed25519 signing key. Keys never leave Lina's device. Non-PRF authenticators get a deliberate fallback (passphrase-derived key or similar) — no silent failure.
+- **Per-share revocation is cryptographic**, not just URL deletion: each share has a bit in a status list Lina publishes. Revoking flips the bit, invalidating cached copies as well.
+- Evidence schema is designed so **each item is atomic** — filename and metadata never leak into digests of adjacent items.
+- Self-signed credentials carry an **honest trust-model footnote** in the UI: Lina's signature proves authorship of the share, not external validation of the claim. External validation is the job of peer / mentor endorsement (Iteration D).
+- **Upgrade path preserved**: if 1EdTech blesses a selective-disclosure cryptosuite (watch `vc-jose-cose` adoption in the OB 3.0 conformance suite), the wrapped-presentation layer can be swapped for SD-JWT VC without changing evidence storage, key management, or the share UI.
+
+---
+
+### Story 3 — Priya verifies a stranger's credential
+
+**Actor:** Priya, 41, hiring manager at a small dev consultancy
+**Actor class:** Third-party verifier
+**Integration mode:** 1
+**Iteration:** A
+**Status:** Target state
+**Claim validated:** `rollercoaster.dev`'s verifier works on any OB3 credential, not just ones we issued.
+
+Priya is reviewing a candidate who included a badge on their CV — something about open-source contributions, issued by a makerspace in Berlin she's never heard of. The link goes to that makerspace's own site, which is slow and partially broken. She copies the badge JSON and pastes it into `rollercoaster.dev/verify`.
+
+In under a second, she gets back: signature valid, issuer key matches the DID published at their domain, not revoked, evidence links resolve. The page also shows her the claim in plain language — _"Completed: Metal Fabrication Fundamentals, 2026-03-14, 40 hours supervised"_ — and the evidence: three workshop photos and an instructor's endorsement. She didn't have to trust the candidate, the makerspace's site, or her own knowledge of Open Badges. She had to trust the math.
+
+She closes the tab. She never created an account. She never will. `rollercoaster.dev` served her in the 90 seconds she had, and that's the only interaction the site ever needed from her.
+
+**Features used:** Universal OB3 verifier, evidence resolution, plain-language credential rendering
+**Why this belongs on web:** Third-party verification is a web-shaped job — it's always "I got a link, I need to check it, I leave." The audience is not the earner and never will be.
+**Anti-requirements this enforces:**
+
+- Verifier accepts any OB3 credential, not just ours
+- No sign-up wall for verification
+- Plain-language rendering is a first-class feature, not a debug view
+
+---
+
+## Iteration B — Orgs can issue, visually
+
+Once the public surface works, the reference implementation earns its second job: a makerspace or workshop organizer can run `openbadges-system` and issue badges to their members without learning the OB3 spec.
+
+---
+
+### Story 4 — The makerspace gives out its first badge
+
+**Actor:** Dani, 38, volunteer tech-lead at a neighborhood makerspace
+**Actor class:** Toolkit consumer #2 (makerspace volunteer) + Operator
+**Integration mode:** 1
+**Iteration:** B
+**Status:** Target state
+**Claim validated:** A semi-technical volunteer can run `openbadges-system` and issue signed badges to real members in under an afternoon.
+
+Dani runs the Thursday night welding intro. Six people finished last month's cohort. She's been promising them certificates "soon" for three weeks and now she's behind.
+
+She deploys `openbadges-system` to the makerspace's little VPS with one `docker compose up`. The admin interface isn't scary — no "Create Issuer Profile" wall, no 14-field forms. The first-run wizard asks for the makerspace's name, contact email, and whether she wants to generate a signing key now or bring her own. Five minutes later she has an issuer identity, signed locally, key material on the VPS disk and nowhere else.
+
+She creates a badge class called "Welding Intro — Thursday Cohort, March 2026." She types a short description, picks a color from the designer, uploads a photo from class. She pastes the six attendees' email addresses into a textarea, clicks _Issue_. Each person gets an email: _"Dani from [Makerspace] gave you a badge. Here's a link to view and save it."_ The link opens on `rollercoaster.dev`-style public page (self-hosted, or at their own domain if they set one up — both work).
+
+One attendee has `native-rd` installed and their badge lands directly in their mobile backpack. Another forwards the link to their LinkedIn. A third forgets about it for two months and then remembers when they're updating their CV. All three paths work.
+
+**Features used:** One-command deployment, first-run wizard, badge class creation, bulk issuance by email, public badge pages at a self-hostable domain, integration with `native-rd` backpack where installed
+**Why this belongs on web:** Dani is not installing a mobile app to issue six badges. She's on a laptop with six email addresses in a spreadsheet.
+**Anti-requirements this enforces:**
+
+- First run takes under 15 minutes from zero to signed badge
+- No story requires creating an "issuer" as a separate onboarding step — identity and first badge are the same flow
+- Email is an acceptable delivery channel; no forced platform install
+
+---
+
+### Story 5 — Dani designs the badge on her laptop
+
+**Actor:** Dani (same as Story 4)
+**Actor class:** Operator
+**Integration mode:** 1 or 2 (standalone designer)
+**Iteration:** B
+**Status:** Target state
+**Claim validated:** The badge designer feels like a real tool on desktop, not a ported mobile UI.
+
+Before issuing, Dani opens the designer. The canvas is big — her whole laptop screen if she wants — and she can drag the badge around with her mouse in a way that never felt right on her phone. She picks a hard-shadow rectangle, black border, yellow fill. She uploads the makerspace's logo. She types "Welding Intro" with a chunky display font and watches it snap to a grid.
+
+She saves the design to her makerspace's library so next month's cohort gets the same visual. Export options: PNG (with OB3 baked into the image metadata), SVG (for embossing onto t-shirts later), and a JSON design file she can share with the next volunteer running the intro. That JSON also opens in `native-rd`'s designer — the tools are the same format across platforms.
+
+**Features used:** Web badge designer, design library, multi-format export, cross-platform design interop with `native-rd`
+**Why this belongs on web:** Visual design is a big-screen job. Mouse precision beats finger dragging on a small canvas. Desktop is where logos already live.
+**Anti-requirements this enforces:**
+
+- Design format is the same file native-rd reads — no silo
+- Designer works without login (saving to library is the only thing that requires account)
+
+---
+
+## Iteration C — Peer signal, web-shaped
+
+Carmen and Kayla from the existing ecosystem stories, reframed for the web surface.
+
+---
+
+### Story 6 — Carmen endorses Kayla, publicly
+
+**Actor:** Carmen, 40, dyslexic — community gardening coordinator
+**Actor class:** Peer / mentor
+**Integration mode:** 1 (both on the same rollercoaster.dev instance) or cross-instance (both on their own deployments)
+**Iteration:** C
+**Status:** Target state — requires native-rd peer flow + web endorsement surface
+**Claim validated:** Peer verification produces a publicly verifiable signal that strengthens the badge without moving ownership away from the earner.
+
+Kayla, 16, has been keeping her "First Garden Bed" badge on her phone for months. She wants to put it on the youth-employment portfolio the community center is building — a plain webpage with her photo, her interests, and a few badges. She copies the `rollercoaster.dev/b/<id>` link from `native-rd` and pastes it into her portfolio.
+
+Carmen sees the portfolio at the community center's sharing night. She taps the badge, reviews Kayla's evidence — the bed photos, the short note about what she learned — and adds her endorsement from her phone. The endorsement posts to the same public page: below Kayla's self-signature, a second signature block appears, signed by Carmen, whose own "Mentor: Raised Bed Gardening" badge is linked and verifiable.
+
+Anyone viewing the portfolio now sees two signatures, both verifiable, both from real people with their own badges. The trust chain is visible without being gamified. Kayla owns the badge. Carmen's name is attached because she chose to put it there.
+
+**Features used:** Cross-signature on a public badge page, endorsement UI, verifiable endorser identity via their own badge
+**Why this belongs on web:** The portfolio is a webpage. The endorsement has to live where the audience (a future employer, a grant reviewer) will see it.
+**Anti-requirements this enforces:**
+
+- Endorsement is additive, never authoritative — can't override the earner's self-signature
+- Endorser's credential (their own badge) is verifiable from the endorsed badge's page
+- No endorsement without the earner's explicit accept
+
+---
+
+### Story 7 — A teacher-training platform issues PD credentials at scale
+
+**Actor:** Marta, 34, lead engineer at a European EdTech platform for teachers
+**Actor class:** Toolkit consumer #3 (institutional platform team)
+**Integration mode:** 2 (embed `openbadges-ui` components) + 3 (headless — call `openbadges-modular-server` from their backend)
+**Iteration:** B
+**Status:** Target state
+**Claim validated:** An existing platform with its own identity system and UI can adopt parts of the toolkit to issue spec-compliant OB 3.0 credentials without rewriting their product.
+
+Marta's platform runs certified professional-development courses for teachers across Germany — hundreds of thousands of accounts, strict GDPR constraints, a long-running Rails-and-React stack she isn't about to refactor. When a teacher completes a course, she wants them to receive a real OB 3.0 credential they can put on their own school's LMS, their CV, or carry into any backpack that speaks the spec.
+
+She is not going to deploy `openbadges-system` as a second app. Her platform already has auth, already has a user database, already has a UI language. She needs **pieces**, not a platform.
+
+She reads the toolkit docs for an afternoon and ends up using three parts: `openbadges-types` for TypeScript safety, `openbadges-core` for signing and PNG baking in a small Node service, and `openbadges-ui`'s Vue components wrapped inside a thin React adapter on the course-completion page (the components render the badge and its verification state; her team owns everything around them). The `openbadges-modular-server` she passes on — her platform already has a database, she just wants the library functions, not a second service.
+
+Issuing flow: a teacher completes "Media Literacy 101." Her backend calls `openbadges-core.issue()` with the teacher's identity (their platform-internal DID, generated from the existing user ID), the badge class her team defined, and a link to the completion evidence (course transcript, reflection). A signed OB 3.0 credential lands in the teacher's account page, rendered by the embedded components. A _Download_ button gives them the PNG with the credential baked in. A _Copy verification URL_ gives them a public link — pointed at `rollercoaster.dev/verify` or at their own self-hosted verifier, her choice.
+
+GDPR holds because the toolkit doesn't phone home. No external server sees the teacher's identity, no telemetry, no hosted dependency. The teacher's credentials live on her platform; the signatures are cryptographic, the verification is offline-capable, and if the teacher wants to move their credentials to a personal backpack later, the OB 3.0 format means they can.
+
+Six weeks from "we should do badges" to first-teacher-issued-in-production. Not because the toolkit is magic, but because she picked the three pieces that fit, ignored the rest, and her own stack stayed intact.
+
+**Features used:** `openbadges-types`, `openbadges-core` as a library (signing, baking, verification), `openbadges-ui` components embeddable in a non-Vue host, stable public API contracts, no phone-home / no hosted dependency
+**Why this belongs on web:** Teacher-facing credentials need to be on the platform the teacher already uses. The integration can't require the platform to host a second service or UI.
+**Anti-requirements this enforces:**
+
+- Toolkit packages are independently useful — you can adopt one without adopting all
+- `openbadges-ui` components do not assume the host app uses Vue (the component layer is framework-agnostic at the public contract, even if the implementation is Vue)
+- No telemetry, no phone-home, no external-service requirement for core issuance or verification
+- Public API contracts stay stable — breaking changes cost the toolkit's trust with platforms
+
+---
+
+## What these seven stories cover
+
+| Story                                   | Actor class           | Integration mode | Iteration | Key surface                        |
+| --------------------------------------- | --------------------- | ---------------- | --------- | ---------------------------------- |
+| 1. _needs rework_                       | —                     | —                | A         | Placeholder                        |
+| 2. Lina chooses what the librarian sees | Earner                | 1                | A         | Selective disclosure + local-first |
+| 3. Priya verifies a stranger            | Verifier              | 1                | A         | Universal OB3 verifier             |
+| 4. Makerspace first badge               | Operator              | 1                | B         | One-command deploy + issuance      |
+| 5. Dani designs on laptop               | Operator              | 1 / 2            | B         | Web badge designer                 |
+| 6. Carmen endorses Kayla                | Peer / mentor         | 1 or cross       | C         | Public endorsement                 |
+| 7. EdTech platform integrates           | Institutional builder | 2 + 3            | B         | Toolkit-as-library, embedded       |
+
+**Gaps I know about but did not fill this pass:**
+
+- No toolkit-consumer-as-indie-dev story yet — write one. The indie dev who adds badges to their SaaS in an afternoon is a target-state story that defines what the toolkit's DX has to feel like. Writing it will surface anti-requirements for `openbadges-core`, `openbadges-types`, and `openbadges-ui`.
+- No CLI story yet — write one. The geeky dev using the CLI from the terminal, and the AI agent scripting credential issuance in CI, are target-state stories that define what the CLI has to be. The CLI doesn't exist yet; that's the point — the story is how we define what it should be.
+- No Badgr-migration story yet — optional. The window is mostly closed but one story could capture the disposition toward importing credentials from defunct platforms.
+- No story about earner creating a badge on the web directly — write one once Open Question #2 is resolved. Whichever way it resolves, a story captures the intended experience.
+
+---
+
+## Change log
+
+- **2026-04-23** — Draft v0.1. Six stories covering Iteration A (web surface), B (org issuance + designer), C (peer endorsement). Focused on what the web does that native-rd doesn't.
+- **2026-04-23** — Added Story 7: institutional platform team integrates the toolkit as a library (Modes 2+3). Anonymized from a real European EdTech platform at ~200k-teacher scale. Fills the LMS-embed gap.
+- **2026-04-23** — Story 1 flagged as needs-rework after author feedback ("not clear, not a full reference deployment, nothing of value"). Placeholder left in slot. Story 2 rewritten to center local-first + user-owned data and per-recipient selective disclosure (hide/show individual evidence per viewer).
+- **2026-04-23 (v0.2)** — Restructured framework after deeper read of native-rd vision docs, ADR-0001, learning-graph.md, and design-principles.md. Added Iteration A–D scope definitions aligned to ADR-0001. Added Task View as cross-iteration primary pattern. Added inherited design principles section. Added Open Questions section capturing personal-vs-institutional tension and four other unresolved decisions that block story rewrites. Individual stories (2–7) NOT yet re-homed into the corrected framework — flagged explicitly in the doc.
+- **2026-04-23 (v0.2.1)** — Corrected gap-list reasoning after author feedback: stories for not-yet-built tools (CLI, AI-agent integration) are not "fiction" — writing them is how the project decides what to build. Gap entries now frame those as stories-to-write, not stories-to-defer. Methodology captured formally in `apps/docs/processes/product-planning.md` and referenced from root `AGENTS.md`.
+- **2026-04-23 (v0.2.2)** — Story 2 anti-requirements extended with architectural commitments from the selective-disclosure feasibility research (`apps/docs/research/selective-disclosure-feasibility-2026-04.md`): content-hash evidence storage, wrapped-presentation shares (not SD-signature derivations), WebAuthn+PRF key management with deliberate fallback, cryptographic per-share revocation via status list, atomic evidence schema, honest self-signed trust-model footnote, SD-JWT-VC upgrade path preserved. Narrative unchanged.


### PR DESCRIPTION
## Summary
- Codifies the **Stories → Vision → Design → ADRs → Build** methodology already proven on `native-rd`, and adds an `AGENTS.md` rule pointing agents at it (with the most common failure modes spelled out).
- Lands the first round of `openbadges-system` / `openbadges-ui` rebuild planning artifacts: vision draft, two research baselines, and v0.2 user stories aligned to native-rd's ADR-0001 iteration framework.
- Adds `.superset/` and `.claude/scheduled_tasks.lock` to `.gitignore` so local tooling artifacts stop showing up in every status check.

## Why now
These docs were written together (all dated 2026-04-23) but never committed — they sat in the working tree across multiple branches. Pulling them onto a dedicated branch keeps planning history reviewable and unblocks future planning agents that need the canonical doc to exist on disk.

## Files
- **`AGENTS.md`** — adds "Product Planning Methodology" section (the agent-facing rule)
- **`apps/docs/processes/product-planning.md`** — canonical methodology doc
- **`apps/docs/vision/openbadges-toolkit-rebuild.md`** — living planning capture (working draft)
- **`apps/docs/research/open-source-badge-server-landscape-2026-04.md`** — competitive baseline
- **`apps/docs/research/selective-disclosure-feasibility-2026-04.md`** — feasibility verdict for per-recipient SD on self-signed OB 3.0
- **`apps/openbadges-system/docs/user-stories.md`** — draft v0.2 user stories
- **`.gitignore`** — ignore `.superset/` and `.claude/scheduled_tasks.lock`

## Test plan
- [ ] Type-check passes (verified locally — turbo cache hits across all 9 packages)
- [ ] Markdown lints cleanly (prettier ran during pre-commit lint-staged)
- [ ] Doc cross-references resolve (links from AGENTS.md → process doc, from user-stories → native-rd ADR-0001)
- [ ] No code changed; CI lint/type-check/test/build should be green from the docs-only diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive product planning methodology and workflow documentation.
  * Introduced research reports on open-source badge ecosystems and selective disclosure feasibility.
  * Published vision document and detailed user stories for the OpenBadges Toolkit rebuild.

* **Chores**
  * Updated configuration to exclude local artifacts from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->